### PR TITLE
fix: fit-demo example fixes

### DIFF
--- a/docker/fit-demo/README.md
+++ b/docker/fit-demo/README.md
@@ -8,6 +8,6 @@ Contains services: arserver, execution, build, project and execution proxy
 ## Uploading object_types to project service
 
 ```bash
-docker run --rm --network="fit-demo_testitoff-robot-network" --env ARCOR2_PERSISTENT_STORAGE_URL=http://project:10000 arcor2/arcor2_upload_fit_demo:VERSION
+docker run --rm --network="fit-demo_testitoff-project-network" --env ARCOR2_PERSISTENT_STORAGE_URL=http://project:10000 arcor2/arcor2_upload_fit_demo:VERSION
 ```
 Network has to be set to any network where project service is accessible. Instead of VERSION use desired version of arcor2_fit_demo package. 

--- a/docker/fit-demo/docker-compose.yml
+++ b/docker/fit-demo/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - ARCOR2_SCENE_SERVICE_URL=http://testitoff-scene-webapi:15000
       - ARCOR2_EXECUTION_URL=ws://execution:6790
       - ARCOR2_BUILD_URL=http://build:5008
+      - ARCOR2_DATA_PATH=/root/data
 
   build:
     image: arcor2/arcor2_build:${ARCOR2_BUILD_VERSION:?ARCOR2_BUILD_VERSION env variable not set}


### PR DESCRIPTION
ARCOR2_DATA_PATH was missing in compose file.

Outdated network name was fixed in README file