### PR TITLE
build: new version of Pants

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.0.0rc1"
+pants_version = "2.0.0rc2"
 colors = true
 pants_distdir_legacy_paths = false
 
@@ -66,3 +66,6 @@ config = [".isort.cfg"]
 [python-infer]
 imports = true
 inits = true
+
+[setup-py-generation]
+first_party_dependency_version_scheme = "compatible"


### PR DESCRIPTION
Inter-repository dependencies (in generated setup.py) are now set to ~= insted of ==