### PR TITLE
fix(arcor2_kinali): removed comments causing AssertionError in horast

### DIFF
--- a/src/python/arcor2_kinali/object_types/kinali_robot.py
+++ b/src/python/arcor2_kinali/object_types/kinali_robot.py
@@ -32,16 +32,16 @@ class MoveTypeEnum(StrEnum):
 class MoveRelativeParameters(JsonSchemaMixin):
 
     pose: Pose
-    position: Position  # relative position
-    orientation: Orientation  # relative orientation
+    position: Position
+    orientation: Orientation
 
 
 @dataclass
 class MoveRelativeJointsParameters(JsonSchemaMixin):
 
     joints: List[Joint]
-    position: Position  # relative position
-    orientation: Orientation  # relative orientation
+    position: Position
+    orientation: Orientation
 
 
 class KinaliRobot(AbstractRobot):


### PR DESCRIPTION
The exact assertion was:
`assert path[-2].node is within_node, (path[-2].node, within_node)`