### PR TITLE
fix: image-related functions

### DIFF
--- a/src/python/arcor2/image.py
+++ b/src/python/arcor2/image.py
@@ -10,9 +10,9 @@ from PIL.Image import Image
 ENCODING = "latin-1"
 
 
-def image_to_cv2(pil_image: Image) -> np.array:
+def image_to_cv2(pil_image: Image, mode=cv2.COLOR_RGB2BGR) -> np.array:
 
-    return cv2.cvtColor(np.array(pil_image), cv2.COLOR_RGB2BGR)
+    return cv2.cvtColor(np.array(pil_image), mode)
 
 
 def image_to_bytes_io(value: Image, target_format: str = "jpeg", target_mode: Optional[str] = None) -> io.BytesIO:
@@ -28,12 +28,12 @@ def image_to_bytes_io(value: Image, target_format: str = "jpeg", target_mode: Op
     return output
 
 
-def image_to_str(value: Image) -> str:
-    return image_to_bytes_io(value).getvalue().decode(ENCODING)
+def image_to_str(value: Image, target_format: str = "jpeg") -> str:
+    return image_to_bytes_io(value, target_format).getvalue().decode(ENCODING)
 
 
 def image_from_str(value: str) -> Image:
-    return image_to_bytes_io(io.BytesIO(value.encode(ENCODING)))
+    return image_from_bytes_io(io.BytesIO(value.encode(ENCODING)))
 
 
 def image_to_json(value: Image) -> str:

--- a/src/python/arcor2/tests/test_image.py
+++ b/src/python/arcor2/tests/test_image.py
@@ -1,0 +1,17 @@
+import numpy as np
+from PIL import Image, ImageChops
+
+from arcor2.image import image_from_str, image_to_str
+
+
+def test_image_str() -> None:
+
+    imarray = np.random.rand(16, 16, 3) * 255
+    img = Image.fromarray(imarray.astype("uint8")).convert("RGB")
+
+    img_str = image_to_str(img, target_format="png")
+    assert isinstance(img_str, str)
+    img2 = image_from_str(img_str)
+
+    diff = ImageChops.difference(img, img2)
+    assert diff.getbbox() is None, "Difference image is not empty!"

--- a/src/python/arcor2_arserver/rpc/scene.py
+++ b/src/python/arcor2_arserver/rpc/scene.py
@@ -14,6 +14,7 @@ from arcor2.clients import aio_scene_service as scene_srv
 from arcor2.data import common, object_type
 from arcor2.data.events import Event, PackageState
 from arcor2.exceptions import Arcor2Exception
+from arcor2.image import image_from_str
 from arcor2_arserver import globals as glob
 from arcor2_arserver import notifications as notif
 from arcor2_arserver.clients import persistent_storage as storage
@@ -507,8 +508,11 @@ async def copy_scene_cb(req: srpc.s.CopyScene.Request, ui: WsClient) -> None:
 # TODO maybe this would better fit into another category of RPCs? Like common/misc?
 async def calibration_cb(req: srpc.c.Calibration.Request, ui: WsClient) -> srpc.c.Calibration.Response:
 
+    # TODO estimated pose should be rather returned in an event (it is possibly a long-running process)
     return srpc.c.Calibration.Response(
-        data=await hlp.run_in_executor(calibration.estimate_camera_pose, req.args.camera_parameters, req.args.image)
+        data=await hlp.run_in_executor(
+            calibration.estimate_camera_pose, req.args.camera_parameters, image_from_str(req.args.image)
+        )
     )
 
 


### PR DESCRIPTION
- arcor2/image.py
  - `image_from_str` fixed
  - minor improvements in other functions
  - test added
- arcor2_arserver
  - `calibration_cb` fixed (missing `image_from_str` added)