### PR TITLE
feat: detect marker corners

### DIFF
--- a/src/python/arcor2_arserver/rpc/scene.py
+++ b/src/python/arcor2_arserver/rpc/scene.py
@@ -516,6 +516,17 @@ async def calibration_cb(req: srpc.c.Calibration.Request, ui: WsClient) -> srpc.
     )
 
 
+# TODO maybe this would better fit into another category of RPCs? Like common/misc?
+async def marker_corners(req: srpc.c.MarkersCorners.Request, ui: WsClient) -> srpc.c.MarkersCorners.Response:
+
+    # TODO should be rather returned in an event (it is possibly a long-running process)
+    return srpc.c.MarkersCorners.Response(
+        data=await hlp.run_in_executor(
+            calibration.markers_corners, req.args.camera_parameters, image_from_str(req.args.image)
+        )
+    )
+
+
 async def start_scene_cb(req: srpc.s.StartScene.Request, ui: WsClient) -> None:
 
     if get_scene_state() != sevts.s.SceneState.Data.StateEnum.Stopped:

--- a/src/python/arcor2_arserver_data/rpc/common.py
+++ b/src/python/arcor2_arserver_data/rpc/common.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
-from typing import Optional, Set
+from typing import List, Optional, Set
 
+from arcor2_calibration_data import MarkerCorners
 from dataclasses_jsonschema import JsonSchemaMixin
 
 from arcor2.data.camera import CameraParameters
@@ -44,3 +45,22 @@ class Calibration(RPC):
     class Response(RPC.Response):
 
         data: Optional[Pose] = None
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class MarkersCorners(RPC):
+    @dataclass
+    class Request(RPC.Request):
+        @dataclass
+        class Args(JsonSchemaMixin):
+            camera_parameters: CameraParameters
+            image: str = field(metadata=dict(description="Base64 encoded image."))
+
+        args: Args
+
+    @dataclass
+    class Response(RPC.Response):
+
+        data: Optional[List[MarkerCorners]] = None

--- a/src/python/arcor2_calibration/scripts/calibration.py
+++ b/src/python/arcor2_calibration/scripts/calibration.py
@@ -4,8 +4,9 @@ import argparse
 import os
 import random
 import time
+from typing import List
 
-from arcor2_calibration_data import CALIBRATION_URL, SERVICE_NAME
+from arcor2_calibration_data import CALIBRATION_URL, SERVICE_NAME, Corner, MarkerCorners
 from arcor2_calibration_data.client import CalibrateRobotArgs
 from flask import jsonify, request
 from PIL import Image
@@ -16,17 +17,30 @@ from arcor2.flask import RespT, create_app, run_app
 from arcor2.helpers import port_from_url
 from arcor2.logging import get_logger
 from arcor2.urdf import urdf_from_url
-from arcor2_calibration.calibration import get_poses
+from arcor2_calibration.calibration import detect_corners, estimate_camera_pose
 from arcor2_calibration.robot import calibrate_robot
 
 logger = get_logger(__name__)
 
-MARKER_SIZE = float(os.getenv("ARCOR2_CALIBRATION_MARKER_SIZE", 0.091))
+MARKER_SIZE = float(os.getenv("ARCOR2_CALIBRATION_MARKER_SIZE", 0.1))
 MARKER_ID = int(os.getenv("ARCOR2_CALIBRATION_MARKER_ID", 10))
 
 _mock: bool = False
 
 app = create_app(__name__)
+
+
+def camera_matrix_from_request() -> List[List[float]]:
+
+    return [
+        [float(request.args["fx"]), 0.00000, float(request.args["cx"])],
+        [0.00000, float(request.args["fy"]), float(request.args["cy"])],
+        [0.00000, 0.00000, 1],
+    ]
+
+
+def dist_matrix_from_request() -> List[float]:
+    return [float(val) for val in request.args.getlist("distCoefs")]
 
 
 @app.route("/calibrate/robot", methods=["PUT"])
@@ -36,7 +50,7 @@ def put_calibrate_robot() -> RespT:
     put:
         description: Get calibration
         tags:
-           - Calibration
+           - Robot
         requestBody:
               content:
                 multipart/form-data:
@@ -84,6 +98,95 @@ def put_calibrate_robot() -> RespT:
     return jsonify(pose.to_dict()), 200
 
 
+@app.route("/markers/corners", methods=["PUT"])
+def get_marker_corners() -> RespT:
+    """Detect marker corners.
+    ---
+    put:
+        description: Detect marker corners
+        tags:
+           - Camera
+        parameters:
+            - in: query
+              name: fx
+              schema:
+                type: number
+                format: float
+              required: true
+              description: unique ID
+            - in: query
+              name: fy
+              schema:
+                type: number
+                format: float
+              required: true
+              description: unique ID
+            - in: query
+              name: cx
+              schema:
+                type: number
+                format: float
+              required: true
+              description: unique ID
+            - in: query
+              name: cy
+              schema:
+                type: number
+                format: float
+              required: true
+              description: unique ID
+            - in: query
+              name: distCoefs
+              schema:
+                type: array
+                items:
+                    type: number
+                    format: float
+              required: true
+              description: unique ID
+        requestBody:
+              content:
+                multipart/form-data:
+                  schema:
+                    type: object
+                    required:
+                        - image
+                    properties:
+                      # 'image' will be the field name in this multipart request
+                      image:
+                        type: string
+                        format: binary
+        responses:
+            200:
+              description: Ok
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                        $ref: MarkerCorners
+
+    """
+
+    file = request.files["image"]
+    camera_matrix = camera_matrix_from_request()
+    image = Image.open(file.stream)
+    dist_matrix = dist_matrix_from_request()
+
+    corners: List[MarkerCorners] = []
+
+    if _mock:
+        time.sleep(0.1)
+        corners = [MarkerCorners(10, [Corner(934, 831), Corner(900, 1007), Corner(663, 999), Corner(741, 828)])]
+    else:
+        _, _, _, detected_corners, ids = detect_corners(camera_matrix, dist_matrix, image)
+
+        for mid, corn in zip(ids, detected_corners[0]):
+            corners.append(MarkerCorners(int(mid), [Corner(float(v[0]), float(v[1])) for v in corn]))
+
+    return jsonify(corners), 200
+
+
 @app.route("/calibrate/camera", methods=["PUT"])
 def get_calibration() -> RespT:
     """Get calibration (camera pose wrt. marker)
@@ -91,7 +194,7 @@ def get_calibration() -> RespT:
     put:
         description: Get calibration
         tags:
-           - Calibration
+           - Camera
         parameters:
             - in: query
               name: fx
@@ -154,27 +257,21 @@ def get_calibration() -> RespT:
 
     file = request.files["image"]
 
-    camera_matrix = [
-        [float(request.args["fx"]), 0.00000, float(request.args["cx"])],
-        [0.00000, float(request.args["fy"]), float(request.args["cy"])],
-        [0.00000, 0.00000, 1],
-    ]
-
+    camera_matrix = camera_matrix_from_request()
     image = Image.open(file.stream)
-
-    dist_matrix = [float(val) for val in request.args.getlist("distCoefs")]
+    dist_matrix = dist_matrix_from_request()
 
     if _mock:
         time.sleep(0.5)
         pose = Pose(Position(random.uniform(-0.5, 0.5), random.uniform(-0.5, 0.5), random.uniform(0.2, 1)))
     else:
-        poses = get_poses(camera_matrix, dist_matrix, image, MARKER_SIZE)
+        poses = estimate_camera_pose(camera_matrix, dist_matrix, image, MARKER_SIZE)
         try:
             pose = poses[MARKER_ID]  # TODO this is just temporary (single-marker) solution
         except KeyError:
             return "Marker not found", 404
 
-    return jsonify(pose.to_dict()), 200
+    return jsonify(pose), 200
 
 
 def main() -> None:
@@ -195,7 +292,7 @@ def main() -> None:
         arcor2_calibration.version(),
         arcor2_calibration.version(),
         port_from_url(CALIBRATION_URL),
-        [Pose, CalibrateRobotArgs],
+        [Pose, CalibrateRobotArgs, MarkerCorners],
         args.swagger,
     )
 

--- a/src/python/arcor2_calibration_data/__init__.py
+++ b/src/python/arcor2_calibration_data/__init__.py
@@ -1,4 +1,8 @@
 import os
+from dataclasses import dataclass
+from typing import List
+
+from dataclasses_jsonschema import JsonSchemaMixin
 
 from arcor2 import package_version
 
@@ -8,3 +12,17 @@ SERVICE_NAME = "ARCOR2 Calibration Service"
 
 def version() -> str:
     return package_version(__name__)
+
+
+@dataclass
+class Corner(JsonSchemaMixin):
+
+    x: float
+    y: float
+
+
+@dataclass
+class MarkerCorners(JsonSchemaMixin):
+
+    marker_id: int
+    corners: List[Corner]

--- a/src/python/arcor2_calibration_data/client.py
+++ b/src/python/arcor2_calibration_data/client.py
@@ -2,13 +2,28 @@ from dataclasses import dataclass
 from io import BytesIO
 from typing import List
 
-from arcor2_calibration_data import CALIBRATION_URL
+from arcor2_calibration_data import CALIBRATION_URL, MarkerCorners
 from dataclasses_jsonschema import JsonSchemaMixin
 from PIL.Image import Image
 
 from arcor2 import rest
 from arcor2.data.camera import CameraParameters
 from arcor2.data.common import Joint, Pose
+
+
+def markers_corners(camera: CameraParameters, image: Image) -> List[MarkerCorners]:
+
+    with BytesIO() as buff:
+
+        image.save(buff, format="PNG")
+
+        return rest.call(
+            rest.Method.PUT,
+            f"{CALIBRATION_URL}/markers/corners",
+            params=camera.to_dict(),
+            list_return_type=MarkerCorners,
+            files={"image": buff.getvalue()},
+        )
 
 
 def estimate_camera_pose(camera: CameraParameters, image: Image) -> Pose:


### PR DESCRIPTION
- Calibration service now has the method `PUT /markers/corners` which returns pixel coordinates of corners of the detected markers.
- ARServer has a new RPC `MarkersCorners` for this.
- Detecting corners is approx. three times faster than camera calibration (which uses the refinement method for higher accuracy).