### PR TITLE
fix(arcor2_arserver): callback name fixed

### DIFF
--- a/src/python/arcor2_arserver/rpc/scene.py
+++ b/src/python/arcor2_arserver/rpc/scene.py
@@ -517,7 +517,7 @@ async def calibration_cb(req: srpc.c.GetCameraPose.Request, ui: WsClient) -> srp
 
 
 # TODO maybe this would better fit into another category of RPCs? Like common/misc?
-async def marker_corners(req: srpc.c.MarkersCorners.Request, ui: WsClient) -> srpc.c.MarkersCorners.Response:
+async def marker_corners_cb(req: srpc.c.MarkersCorners.Request, ui: WsClient) -> srpc.c.MarkersCorners.Response:
 
     # TODO should be rather returned in an event (it is possibly a long-running process)
     return srpc.c.MarkersCorners.Response(


### PR DESCRIPTION
- Callback of `MarkersCorners` RPC was missing `_cb` suffix.
- Because of this, it was not recognized as an RPC callback.