### PR TITLE
fix: the RelativePose was not handled right

### DIFF
--- a/src/python/arcor2/data/common.py
+++ b/src/python/arcor2/data/common.py
@@ -190,6 +190,10 @@ class Pose(JsonSchemaMixin):
         return Pose(Position(tvec[0], tvec[1], tvec[2]), o)
 
 
+class RelativePose(Pose):
+    pass
+
+
 @dataclass
 class ActionMetadata(JsonSchemaMixin):
 

--- a/src/python/arcor2/parameter_plugins/base.py
+++ b/src/python/arcor2/parameter_plugins/base.py
@@ -1,6 +1,6 @@
 import abc
 import json
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Any, Callable, List, NamedTuple, Optional
 
 import humps
 from typed_ast import ast3 as ast
@@ -107,7 +107,7 @@ class ParameterPlugin(metaclass=abc.ABCMeta):
     @classmethod
     def need_to_be_imported(
         cls, type_defs: TypesDict, scene: CScene, project: CProject, action_id: str, parameter_id: str
-    ) -> Optional[ImportTuple]:
+    ) -> Optional[List[ImportTuple]]:
         return None
 
     @classmethod

--- a/src/python/arcor2/parameter_plugins/integer_enum.py
+++ b/src/python/arcor2/parameter_plugins/integer_enum.py
@@ -2,7 +2,7 @@ import inspect
 import json
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Optional, Set, get_type_hints
+from typing import Any, Callable, List, Optional, Set, get_type_hints
 
 from dataclasses_jsonschema import JsonSchemaMixin
 from typed_ast import ast3 as ast
@@ -90,11 +90,13 @@ class IntegerEnumPlugin(ParameterPlugin):
     @classmethod
     def need_to_be_imported(
         cls, type_defs: TypesDict, scene: CScene, project: CProject, action_id: str, parameter_id: str
-    ) -> Optional[ImportTuple]:
+    ) -> Optional[List[ImportTuple]]:
 
         enum_cls = cls.parameter_value(type_defs, scene, project, action_id, parameter_id).__class__
         # TODO does this work as expected in all cases?
         module = inspect.getmodule(enum_cls)
         if not module:
             raise ParameterPluginException("Failed to get the module.")
-        return ImportTuple(module.__name__.split(".")[-1], enum_cls.__name__)
+
+        # TODO enums are typically defined in the same module as a object type but could be def. elsewhere (arcor2.data)
+        return [ImportTuple(f"object_types.{module.__name__.split('.')[-1]}", enum_cls.__name__)]

--- a/src/python/arcor2/parameter_plugins/relative_pose.py
+++ b/src/python/arcor2/parameter_plugins/relative_pose.py
@@ -1,17 +1,13 @@
-from typing import Any
+from typing import Any, List, Optional
 
 from dataclasses_jsonschema import ValidationError
 from typed_ast.ast3 import Call, Load, Name, Num
 
+import arcor2.data.common
 from arcor2.cached import CachedProject as CProject
 from arcor2.cached import CachedScene as CScene
-from arcor2.data.common import Orientation, Pose, Position
-from arcor2.parameter_plugins.base import ParameterPlugin, ParameterPluginException, TypesDict
-
-
-# TODO should it be defined here or in e.g. arcor2.data.common?
-class RelativePose(Pose):
-    pass
+from arcor2.data.common import Orientation, Position, RelativePose
+from arcor2.parameter_plugins.base import ImportTuple, ParameterPlugin, ParameterPluginException, TypesDict
 
 
 class RelativePosePlugin(ParameterPlugin):
@@ -41,8 +37,7 @@ class RelativePosePlugin(ParameterPlugin):
         val = cls.parameter_value(type_defs, scene, project, action_id, parameter_id)
 
         return Call(
-            # TODO should this be RelativePose (must be imported) instead of Pose?
-            func=Name(id=Pose.__name__, ctx=Load()),
+            func=Name(id=RelativePose.__name__, ctx=Load()),
             args=[
                 Call(
                     func=Name(id=Position.__name__, ctx=Load()),
@@ -62,3 +57,16 @@ class RelativePosePlugin(ParameterPlugin):
             ],
             keywords=[],
         )
+
+    @classmethod
+    def need_to_be_imported(
+        cls, type_defs: TypesDict, scene: CScene, project: CProject, action_id: str, parameter_id: str
+    ) -> Optional[List[ImportTuple]]:
+
+        mod = arcor2.data.common.__name__
+
+        return [
+            ImportTuple(mod, RelativePose.__name__),
+            ImportTuple(mod, Position.__name__),
+            ImportTuple(mod, Orientation.__name__),
+        ]

--- a/src/python/arcor2_build/source/logic.py
+++ b/src/python/arcor2_build/source/logic.py
@@ -138,11 +138,12 @@ def add_logic_to_loop(type_defs: TypesDict, tree: Module, scene: CScene, project
 
                 args.append(plugin.parameter_ast(type_defs, scene, project, current_action.id, param.name))
 
-                imp_tup = plugin.need_to_be_imported(type_defs, scene, project, current_action.id, param.name)
+                list_of_imp_tup = plugin.need_to_be_imported(type_defs, scene, project, current_action.id, param.name)
 
-                if imp_tup:
+                if list_of_imp_tup:
                     # TODO what if there are two same names?
-                    add_import(tree, f"object_types.{imp_tup.module_name}", imp_tup.class_name, try_to_import=False)
+                    for imp_tup in list_of_imp_tup:
+                        add_import(tree, imp_tup.module_name, imp_tup.class_name, try_to_import=False)
 
         add_method_call(
             container.body,

--- a/src/python/arcor2_kinali/object_types/aubo.py
+++ b/src/python/arcor2_kinali/object_types/aubo.py
@@ -5,8 +5,7 @@ from dataclasses_jsonschema import JsonSchemaMixin
 
 from arcor2 import DynamicParamTuple as DPT
 from arcor2 import rest
-from arcor2.data.common import ActionMetadata, Joint, Orientation, Pose, Position, ProjectRobotJoints
-from arcor2.parameter_plugins.relative_pose import RelativePose
+from arcor2.data.common import ActionMetadata, Joint, Orientation, Pose, Position, ProjectRobotJoints, RelativePose
 
 from .abstract_robot import AbstractRobot, MoveTypeEnum, lru_cache
 


### PR DESCRIPTION
- `RelativePose` definition moved to `arcor2.data.common`.
- The main script now properly imports `RelativePose`, `Position` and `Orientation`.