### PR TITLE
feat: tests for valid name/type now do not insist on format

### DIFF
--- a/src/python/arcor2/helpers.py
+++ b/src/python/arcor2/helpers.py
@@ -24,24 +24,17 @@ class TypeDefException(Arcor2Exception):
 
 def is_valid_identifier(value: str) -> bool:
     """
-    Identifier (e.g. object id) will be used as variable name in the script - it should be in snake_case,
-    not containing any special characters etc.
+    Identifier (e.g. object id) will be used as variable name in the script - it should
+    not contain any special characters etc.
     :param value:
     :return:
     """
 
-    return value.isidentifier() and not keyword.iskeyword(value) and humps.is_snakecase(value)
+    return value.isidentifier() and not keyword.iskeyword(value)
 
 
 def is_valid_type(value: str) -> bool:
-    """
-    Value will be used as object type name - it should be in CamelCase,
-    not containing any special characters etc.
-    :param value:
-    :return:
-    """
-
-    return value.isidentifier() and not keyword.iskeyword(value) and humps.is_pascalcase(value)
+    return is_valid_identifier(value)
 
 
 S = TypeVar("S")

--- a/src/python/arcor2/tests/test_helpers.py
+++ b/src/python/arcor2/tests/test_helpers.py
@@ -9,10 +9,10 @@ from arcor2 import helpers as hlp
         "valid",
         "valid_ident",
         "abc",
-        pytest.param("InvalidIdent", marks=pytest.mark.xfail),
+        "InvalidIdent",
         pytest.param("invalid ident", marks=pytest.mark.xfail),
         pytest.param("invalid?ident", marks=pytest.mark.xfail),
-        pytest.param("Abc", marks=pytest.mark.xfail),
+        "Abc",
         pytest.param("def", marks=pytest.mark.xfail),
         pytest.param("class", marks=pytest.mark.xfail),
     ],
@@ -26,10 +26,10 @@ def test_is_valid_identifier(val) -> None:
     [
         "Valid",
         "ValidType",
-        pytest.param("invalid_type", marks=pytest.mark.xfail),
+        "invalid_type",
         pytest.param("Invalid Type", marks=pytest.mark.xfail),
         pytest.param("invalid?type", marks=pytest.mark.xfail),
-        pytest.param("abc", marks=pytest.mark.xfail),
+        "abc",
     ],
 )
 def test_is_valid_type(val) -> None:


### PR DESCRIPTION
- `is_valid_identifier` now behaves the same as `is_valid_type`.
- There is no convention (PascalCase vs snake_case) checking.