### PR TITLE
feat: standard robot API now has safe parameter

### DIFF
--- a/src/python/arcor2/object_types/abstract.py
+++ b/src/python/arcor2/object_types/abstract.py
@@ -166,23 +166,25 @@ class Robot(GenericWithPose, metaclass=abc.ABCMeta):
     def suctions(self) -> Set[str]:
         return set()
 
-    def move_to_pose(self, end_effector_id: str, target_pose: Pose, speed: float) -> None:
+    def move_to_pose(self, end_effector_id: str, target_pose: Pose, speed: float, safe: bool = True) -> None:
         """Move given robot's end effector to the selected pose.
 
         :param end_effector_id:
         :param target_pose:
         :param speed:
+        :param safe:
         :return:
         """
 
         assert 0.0 <= speed <= 1.0
         raise NotImplementedError("Robot does not support moving to pose.")
 
-    def move_to_joints(self, target_joints: List[Joint], speed: float) -> None:
+    def move_to_joints(self, target_joints: List[Joint], speed: float, safe: bool = True) -> None:
         """Sets target joint values.
 
         :param target_joints:
         :param speed:
+        :param safe:
         :return:
         """
 

--- a/src/python/arcor2_arserver/rpc/robot.py
+++ b/src/python/arcor2_arserver/rpc/robot.py
@@ -239,7 +239,9 @@ async def move_to_pose_cb(req: srpc.r.MoveToPose.Request, ui: WsClient) -> None:
         raise Arcor2Exception("Position or orientation should be given.")
 
     # TODO check if the target pose is reachable (dry_run)
-    asyncio.ensure_future(robot.move_to_pose(req.args.robot_id, req.args.end_effector_id, target_pose, req.args.speed))
+    asyncio.ensure_future(
+        robot.move_to_pose(req.args.robot_id, req.args.end_effector_id, target_pose, req.args.speed, req.args.safe)
+    )
 
 
 @scene_needed
@@ -248,7 +250,7 @@ async def move_to_joints_cb(req: srpc.r.MoveToJoints.Request, ui: WsClient) -> N
     ensure_scene_started()
     await check_feature(req.args.robot_id, Robot.move_to_joints.__name__)
     await robot.check_robot_before_move(req.args.robot_id)
-    asyncio.ensure_future(robot.move_to_joints(req.args.robot_id, req.args.joints, req.args.speed))
+    asyncio.ensure_future(robot.move_to_joints(req.args.robot_id, req.args.joints, req.args.speed, req.args.safe))
 
 
 @scene_needed
@@ -284,7 +286,12 @@ async def move_to_action_point_cb(req: srpc.r.MoveToActionPoint.Request, ui: WsC
         # TODO check if the target pose is reachable (dry_run)
         asyncio.ensure_future(
             robot.move_to_ap_orientation(
-                req.args.robot_id, req.args.end_effector_id, pose, req.args.speed, req.args.orientation_id
+                req.args.robot_id,
+                req.args.end_effector_id,
+                pose,
+                req.args.speed,
+                req.args.orientation_id,
+                req.args.safe,
             )
         )
 
@@ -296,7 +303,7 @@ async def move_to_action_point_cb(req: srpc.r.MoveToActionPoint.Request, ui: WsC
 
         # TODO check if the joints are within limits and reachable (dry_run)
         asyncio.ensure_future(
-            robot.move_to_ap_joints(req.args.robot_id, joints.joints, req.args.speed, req.args.joints_id)
+            robot.move_to_ap_joints(req.args.robot_id, joints.joints, req.args.speed, req.args.joints_id, req.args.safe)
         )
 
 

--- a/src/python/arcor2_arserver_data/events/robot.py
+++ b/src/python/arcor2_arserver_data/events/robot.py
@@ -52,6 +52,7 @@ class RobotMoveToPose(Event):
     class Data(RobotMoveToData):
         end_effector_id: str
         target_pose: common.Pose
+        safe: bool
         message: Optional[str] = None
 
     data: Data
@@ -65,6 +66,7 @@ class RobotMoveToJoints(Event):
     @dataclass
     class Data(RobotMoveToData):
         target_joints: List[common.Joint]
+        safe: bool
         message: Optional[str] = None
 
     data: Data
@@ -79,6 +81,7 @@ class RobotMoveToActionPointOrientation(Event):
     class Data(RobotMoveToData):
         end_effector_id: str
         orientation_id: str
+        safe: bool
         message: Optional[str] = None
 
     data: Data
@@ -92,6 +95,7 @@ class RobotMoveToActionPointJoints(Event):
     @dataclass
     class Data(RobotMoveToData):
         joints_id: str
+        safe: bool
         message: Optional[str] = None
 
     data: Data

--- a/src/python/arcor2_arserver_data/rpc/robot.py
+++ b/src/python/arcor2_arserver_data/rpc/robot.py
@@ -140,6 +140,7 @@ class MoveToPose(RPC):
             speed: float
             position: Optional[Position]
             orientation: Optional[Orientation]
+            safe: bool = True
 
         args: Args
 
@@ -176,6 +177,7 @@ class MoveToJoints(RPC):
             robot_id: str
             speed: float
             joints: List[Joint]
+            safe: bool = True
 
         args: Args
 
@@ -197,6 +199,7 @@ class MoveToActionPoint(RPC):
             end_effector_id: Optional[str] = None
             orientation_id: Optional[str] = None
             joints_id: Optional[str] = None
+            safe: bool = True
 
         args: Args
 

--- a/src/python/arcor2_fit_demo/object_types/abstract_dobot.py
+++ b/src/python/arcor2_fit_demo/object_types/abstract_dobot.py
@@ -5,6 +5,7 @@ from arcor2 import DynamicParamTuple as DPT
 from arcor2 import rest
 from arcor2.data.common import ActionMetadata, Joint, Pose, StrEnum
 from arcor2.data.robot import RobotType
+from arcor2.exceptions import Arcor2NotImplemented
 from arcor2.object_types.abstract import Robot, RobotException, Settings
 
 # TODO jogging
@@ -62,10 +63,14 @@ class AbstractDobot(Robot):
     def get_end_effector_pose(self, end_effector_id: str) -> Pose:
         return rest.call(rest.Method.GET, f"{self.settings.url}/eef/pose", return_type=Pose)
 
-    def move_to_pose(self, end_effector_id: str, target_pose: Pose, speed: float) -> None:
+    def move_to_pose(self, end_effector_id: str, target_pose: Pose, speed: float, safe: bool = False) -> None:
+        if safe:
+            raise Arcor2NotImplemented("Dobot does not support safe moves.")
         self.move(target_pose, MoveType.LINEAR, speed * 100)
 
-    def move_to_joints(self, target_joints: List[Joint], speed: float) -> None:
+    def move_to_joints(self, target_joints: List[Joint], speed: float, safe: bool = False) -> None:
+        if safe:
+            raise Arcor2NotImplemented("Dobot does not support safe moves.")
         self.move(self.forward_kinematics("", target_joints), MoveType.LINEAR, speed * 100)
 
     def home(self, *, an: Optional[str] = None) -> None:

--- a/src/python/arcor2_kinali/object_types/abstract_robot.py
+++ b/src/python/arcor2_kinali/object_types/abstract_robot.py
@@ -60,6 +60,9 @@ class AbstractRobot(Robot):
         super(AbstractRobot, self).cleanup()
         rest.call(rest.Method.PUT, f"{self.settings.url}/system/reset")
 
+    def move_to_joints(self, target_joints: List[Joint], speed: float, safe: bool = True) -> None:
+        self.set_joints(ProjectRobotJoints("", "", "", target_joints), MoveTypeEnum.SIMPLE, speed, safe=safe)
+
     # --- Grippers Controller ------------------------------------------------------------------------------------------
 
     @lru_cache()

--- a/src/python/arcor2_kinali/object_types/aubo.py
+++ b/src/python/arcor2_kinali/object_types/aubo.py
@@ -32,11 +32,8 @@ class Aubo(AbstractRobot):
     _ABSTRACT = False
     urdf_package_name = "aubo.zip"
 
-    def move_to_pose(self, end_effector_id: str, target_pose: Pose, speed: float) -> None:
-        self.move(end_effector_id, target_pose, MoveTypeEnum.SIMPLE, speed, safe=True)
-
-    def move_to_joints(self, target_joints: List[Joint], speed: float) -> None:
-        self.set_joints(ProjectRobotJoints("", "", "", target_joints), MoveTypeEnum.SIMPLE, speed, safe=True)
+    def move_to_pose(self, end_effector_id: str, target_pose: Pose, speed: float, safe: bool = True) -> None:
+        self.move(end_effector_id, target_pose, MoveTypeEnum.SIMPLE, speed, safe=safe)
 
     # --- EndEffectors Controller --------------------------------------------------------------------------------------
 

--- a/src/python/arcor2_kinali/object_types/simatic.py
+++ b/src/python/arcor2_kinali/object_types/simatic.py
@@ -1,6 +1,6 @@
-from typing import Set
+from typing import List, Set
 
-from arcor2.data.common import Pose
+from arcor2.data.common import Joint, Pose
 from arcor2.exceptions import Arcor2NotImplemented
 from arcor2.object_types.abstract import RobotType
 
@@ -21,3 +21,8 @@ class Simatic(AbstractRobot):
 
     def suctions(self) -> Set[str]:
         return set()
+
+    def move_to_joints(self, target_joints: List[Joint], speed: float, safe: bool = False) -> None:
+        if safe:
+            raise Arcor2NotImplemented("Simatic does not support safe moves.")
+        super().move_to_joints(target_joints, speed, safe)


### PR DESCRIPTION
- Robot RPCs updated (MoveToPose, MoveToJoints, MoveToActionPoint).
- Dobot robots will raise exception when `safe=True`.
- `Simatic` robot was missing `move_to_joints` (moved to `AbstractRobot`).