### PR TITLE
feat(arcor2_build): import execution package to the Project service

### DIFF
--- a/src/python/arcor2/clients/persistent_storage.py
+++ b/src/python/arcor2/clients/persistent_storage.py
@@ -96,7 +96,7 @@ def update_scene(scene: Scene) -> datetime:
 def update_project_sources(project_sources: ProjectSources) -> None:
 
     assert project_sources.id
-    rest.call(rest.Method.POST, f"{URL}/project/sources", body=project_sources)
+    rest.call(rest.Method.PUT, f"{URL}/sources", body=project_sources)
 
 
 @handle(ProjectServiceException, message="Failed to add or update the object type.")

--- a/src/python/arcor2/flask.py
+++ b/src/python/arcor2/flask.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from typing import List, Optional, Tuple, Type, Union
@@ -13,6 +14,12 @@ from flask_swagger_ui import get_swaggerui_blueprint
 from arcor2.exceptions import Arcor2Exception
 
 RespT = Union[Response, Tuple[str, int]]
+
+
+class FlaskException(Arcor2Exception):
+    def __init__(self, *args, error_code: int):
+        super().__init__(*args)
+        self.error_code = error_code
 
 
 def create_app(import_name: str) -> Flask:
@@ -57,8 +64,12 @@ def run_app(
         return jsonify(spec.to_dict())
 
     @app.errorhandler(Arcor2Exception)
-    def handle_bad_request(e: Arcor2Exception) -> Tuple[str, int]:
-        return str(e), 400
+    def handle_bad_request_general(e: Arcor2Exception) -> Tuple[str, int]:
+        return json.dumps(str(e)), 400
+
+    @app.errorhandler(FlaskException)
+    def handle_bad_request_intentional(e: FlaskException) -> Tuple[str, int]:
+        return json.dumps(str(e)), e.error_code
 
     SWAGGER_URL = "/swagger"
 


### PR DESCRIPTION
- A new method `PUT /project/import` to import the existing execution package.
- Import fails if data already exists and there is any difference.
- Import can be forced by setting the `overwrite` parameter.
- Build now returns response messages in JSON.
- Project service client: fix of `update_project_sources`.