### PR TITLE
feat: uuid ids are now generated by a base class

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -1,6 +1,7 @@
 [GLOBAL]
 pants_version = "2.4.0.dev0"
 colors = true
+process_execution_local_parallelism = 4
 
 
 plugins = [

--- a/src/python/arcor2/cached.py
+++ b/src/python/arcor2/cached.py
@@ -37,7 +37,7 @@ class CachedScene:
 
     @property
     def bare(self) -> cmn.BareScene:
-        return cmn.BareScene(self.id, self.name, self.desc, self.modified, self.int_modified)
+        return cmn.BareScene(self.name, self.desc, self.modified, self.int_modified, id=self.id)
 
     def object_names(self) -> Iterator[str]:
 
@@ -166,7 +166,7 @@ class CachedProject:
             if ap.id in self._action_points:
                 raise CachedProjectException(f"Duplicate AP id: {ap.id}.")
 
-            bare_ap = cmn.BareActionPoint(ap.id, ap.name, ap.position, ap.parent)
+            bare_ap = cmn.BareActionPoint(ap.name, ap.position, ap.parent, id=ap.id)
             self._action_points[ap.id] = bare_ap
 
             for ac in ap.actions:
@@ -242,7 +242,7 @@ class CachedProject:
 
     @property
     def bare(self) -> cmn.BareProject:
-        return cmn.BareProject(self.id, self.name, self.scene_id, self.desc, self.has_logic)
+        return cmn.BareProject(self.name, self.scene_id, self.desc, self.has_logic, id=self.id)
 
     @property
     def action_points(self) -> ValuesView[cmn.BareActionPoint]:
@@ -538,7 +538,7 @@ class UpdateableCachedProject(CachedProject):
             ap.position = position
             ap.parent = parent
         except CachedProjectException:
-            ap = cmn.BareActionPoint(ap_id, name, position, parent)
+            ap = cmn.BareActionPoint(name, position, parent, id=ap_id)
             self._action_points[ap_id] = ap
         self.update_modified()
         return ap

--- a/src/python/arcor2/data/__init__.py
+++ b/src/python/arcor2/data/__init__.py
@@ -25,7 +25,7 @@ def compile_json_schemas() -> None:
 
         for _, obj in inspect.getmembers(module, inspect.isclass):
 
-            if not issubclass(obj, JsonSchemaMixin) or obj is JsonSchemaMixin:
+            if not issubclass(obj, JsonSchemaMixin) or obj is JsonSchemaMixin or inspect.isabstract(obj):
                 continue
 
             try:

--- a/src/python/arcor2/data/common.py
+++ b/src/python/arcor2/data/common.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
+import abc
+import copy
 import math
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, unique
 from json import JSONEncoder
-from typing import Any, ClassVar, Iterator, List, NamedTuple, Optional, Set, cast
+from typing import Any, ClassVar, Iterator, List, NamedTuple, Optional, Set, TypeVar, cast
 
 import numpy as np
 import quaternion
@@ -13,8 +17,12 @@ from dataclasses_jsonschema import JsonSchemaMixin
 from arcor2.exceptions import Arcor2Exception
 
 
-def uid() -> str:
-    return uuid.uuid4().hex
+def uid(prefix: str) -> str:
+
+    if not (prefix and prefix[0].isalpha() and prefix[-1] != "_"):
+        raise Arcor2Exception(f"{prefix} is a invalid uid prefix.")
+
+    return f"{prefix}_{uuid.uuid4().hex}"
 
 
 @unique
@@ -80,7 +88,7 @@ class Position(IterableIndexable):
     y: float = 0.0
     z: float = 0.0
 
-    def rotated(self, rot: "Orientation", inverse: bool = False) -> "Position":
+    def rotated(self, rot: Orientation, inverse: bool = False) -> Position:
 
         q = rot.as_quaternion()
 
@@ -159,12 +167,44 @@ class Orientation(IterableIndexable):
         self.w = nq.w
 
 
-@dataclass
-class NamedOrientation(JsonSchemaMixin):
+class ModelMixin(abc.ABC):
+    """Mixin for objects with 'id' property that is uuid."""
 
     id: str
+
+    @classmethod
+    @abc.abstractmethod
+    def uid_prefix(cls) -> str:
+        pass
+
+    @classmethod
+    def uid(cls) -> str:
+        """Returns uid with proper prefix.
+
+        :return:
+        """
+        return uid(cls.uid_prefix())
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            self.id = self.uid()
+
+
+@dataclass
+class NamedOrientation(JsonSchemaMixin, ModelMixin):
+
     name: str
     orientation: Orientation
+    id: str = ""
+
+    @classmethod
+    def uid_prefix(cls) -> str:
+        return "ori"
+
+    def copy(self) -> NamedOrientation:
+        c = copy.deepcopy(self)
+        c.id = self.uid()
+        return c
 
 
 @dataclass
@@ -182,7 +222,7 @@ class Pose(JsonSchemaMixin):
         return arr
 
     @staticmethod
-    def from_transformation_matrix(matrix: np.ndarray) -> "Pose":
+    def from_transformation_matrix(matrix: np.ndarray) -> Pose:
 
         tvec = matrix[:3, 3]
         o = Orientation()
@@ -211,13 +251,22 @@ class Joint(JsonSchemaMixin):
 
 
 @dataclass
-class ProjectRobotJoints(JsonSchemaMixin):
+class ProjectRobotJoints(JsonSchemaMixin, ModelMixin):
 
-    id: str
     name: str
     robot_id: str
     joints: List[Joint]
     is_valid: bool = False
+    id: str = ""
+
+    @classmethod
+    def uid_prefix(cls) -> str:
+        return "joi"
+
+    def copy(self) -> ProjectRobotJoints:
+        c = copy.deepcopy(self)
+        c.id = self.uid()
+        return c
 
 
 @dataclass
@@ -229,24 +278,44 @@ class Parameter(JsonSchemaMixin):
 
 
 @dataclass
-class SceneObject(JsonSchemaMixin):
+class SceneObject(JsonSchemaMixin, ModelMixin):
 
-    id: str
     name: str
     type: str
     pose: Optional[Pose] = None
     parameters: List[Parameter] = field(default_factory=list)
-    children: List["SceneObject"] = field(default_factory=list)
+    children: List[SceneObject] = field(default_factory=list)
+    id: str = ""
+
+    @classmethod
+    def uid_prefix(cls) -> str:
+        return "obj"
+
+    def copy(self) -> SceneObject:
+        c = copy.deepcopy(self)
+        c.id = self.uid()
+        return c
 
 
 @dataclass
-class BareScene(JsonSchemaMixin):
+class BareScene(JsonSchemaMixin, ModelMixin):
 
-    id: str
     name: str
     desc: str = field(default_factory=str)
     modified: Optional[datetime] = None
     int_modified: Optional[datetime] = None
+    id: str = ""
+
+    @classmethod
+    def uid_prefix(cls) -> str:
+        return "scn"
+
+    SCN = TypeVar("SCN", bound="BareScene")
+
+    def copy(self: SCN) -> SCN:
+        c = copy.deepcopy(self)
+        c.id = self.uid()
+        return c
 
 
 @dataclass
@@ -255,8 +324,8 @@ class Scene(BareScene):
     objects: List[SceneObject] = field(default_factory=list)
 
     @staticmethod
-    def from_bare(bare: BareScene) -> "Scene":
-        return Scene(bare.id, bare.name, bare.desc, bare.modified, bare.int_modified)
+    def from_bare(bare: BareScene) -> Scene:
+        return Scene(bare.name, bare.desc, bare.modified, bare.int_modified, id=bare.id)
 
 
 @dataclass
@@ -298,11 +367,22 @@ class Flow(JsonSchemaMixin):
 
 
 @dataclass
-class BareAction(JsonSchemaMixin):
+class BareAction(JsonSchemaMixin, ModelMixin):
 
-    id: str
     name: str
     type: str
+    id: str = ""
+
+    @classmethod
+    def uid_prefix(cls) -> str:
+        return "act"
+
+    ACT = TypeVar("ACT", bound="BareAction")
+
+    def copy(self: ACT) -> ACT:
+        c = copy.deepcopy(self)
+        c.id = self.uid()
+        return c
 
 
 @dataclass
@@ -333,7 +413,7 @@ class Action(BareAction):
 
     @property
     def bare(self) -> BareAction:
-        return BareAction(self.id, self.name, self.type)
+        return BareAction(self.name, self.type, id=self.id)
 
     def flow(self, flow_type: FlowTypes = FlowTypes.DEFAULT) -> Flow:
 
@@ -344,12 +424,23 @@ class Action(BareAction):
 
 
 @dataclass
-class BareActionPoint(JsonSchemaMixin):
+class BareActionPoint(JsonSchemaMixin, ModelMixin):
 
-    id: str
     name: str
     position: Position
     parent: Optional[str] = None
+    id: str = ""
+
+    @classmethod
+    def uid_prefix(cls) -> str:
+        return "acp"
+
+    ACP = TypeVar("ACP", bound="BareActionPoint")
+
+    def copy(self: ACP) -> ACP:
+        c = copy.deepcopy(self)
+        c.id = self.uid()
+        return c
 
 
 @dataclass
@@ -360,8 +451,8 @@ class ActionPoint(BareActionPoint):
     actions: List[Action] = field(default_factory=list)
 
     @staticmethod
-    def from_bare(bare: BareActionPoint) -> "ActionPoint":
-        return ActionPoint(bare.id, bare.name, bare.position, bare.parent)
+    def from_bare(bare: BareActionPoint) -> ActionPoint:
+        return ActionPoint(bare.name, bare.position, bare.parent, id=bare.id)
 
 
 @dataclass
@@ -375,7 +466,7 @@ class ProjectLogicIf(JsonSchemaMixin):
 
 
 @dataclass
-class LogicItem(JsonSchemaMixin):
+class LogicItem(JsonSchemaMixin, ModelMixin):
     class ParsedStart(NamedTuple):
 
         start_action_id: str
@@ -384,10 +475,10 @@ class LogicItem(JsonSchemaMixin):
     START: ClassVar[str] = "START"
     END: ClassVar[str] = "END"
 
-    id: str
     start: str
     end: str
     condition: Optional[ProjectLogicIf] = None
+    id: str = ""
 
     def parse_start(self) -> ParsedStart:
 
@@ -398,14 +489,27 @@ class LogicItem(JsonSchemaMixin):
 
         return self.ParsedStart(start_action_id, start_flow)
 
+    @classmethod
+    def uid_prefix(cls) -> str:
+        return "lit"
+
+    def copy(self) -> LogicItem:
+        c = copy.deepcopy(self)
+        c.id = self.uid()
+        return c
+
 
 @dataclass
-class ProjectConstant(JsonSchemaMixin):
+class ProjectConstant(JsonSchemaMixin, ModelMixin):
 
-    id: str
     name: str
     type: str
     value: str
+    id: str = ""
+
+    @classmethod
+    def uid_prefix(cls) -> str:
+        return "pco"
 
 
 @dataclass
@@ -416,14 +520,14 @@ class FunctionReturns(JsonSchemaMixin):
 
 
 @dataclass
-class ProjectFunction(JsonSchemaMixin):
+class ProjectFunction(JsonSchemaMixin, ModelMixin):
 
-    id: str
     name: str
     actions: List[Action] = field(default_factory=list)
     logic: List[LogicItem] = field(default_factory=list)
     parameters: List[ActionParameter] = field(default_factory=list)
     returns: List[FunctionReturns] = field(default_factory=list)
+    id: str = ""
 
     def action_ids(self) -> Set[str]:
         return {act.id for act in self.actions}
@@ -436,24 +540,44 @@ class ProjectFunction(JsonSchemaMixin):
         else:
             raise Arcor2Exception("Action not found")
 
+    @classmethod
+    def uid_prefix(cls) -> str:
+        return "pfu"
+
+    def copy(self) -> ProjectFunction:
+        c = copy.deepcopy(self)
+        c.id = self.uid()
+        return c
+
 
 @dataclass
 class SceneObjectOverride(JsonSchemaMixin):
 
-    id: str
+    id: str  # object id
     parameters: List[Parameter]
 
 
 @dataclass
-class BareProject(JsonSchemaMixin):
+class BareProject(JsonSchemaMixin, ModelMixin):
 
-    id: str
     name: str
     scene_id: str
     desc: str = field(default_factory=str)
     has_logic: bool = True
     modified: Optional[datetime] = None
     int_modified: Optional[datetime] = None
+    id: str = ""
+
+    @classmethod
+    def uid_prefix(cls) -> str:
+        return "pro"
+
+    PRO = TypeVar("PRO", bound="BareProject")
+
+    def copy(self: PRO) -> PRO:
+        c = copy.deepcopy(self)
+        c.id = self.uid()
+        return c
 
 
 @dataclass
@@ -466,8 +590,10 @@ class Project(BareProject):
     object_overrides: List[SceneObjectOverride] = field(default_factory=list)
 
     @staticmethod
-    def from_bare(bare: BareProject) -> "Project":
-        return Project(bare.id, bare.name, bare.scene_id, bare.desc, bare.has_logic, bare.modified, bare.int_modified)
+    def from_bare(bare: BareProject) -> Project:
+        return Project(
+            bare.name, bare.scene_id, bare.desc, bare.has_logic, bare.modified, bare.int_modified, id=bare.id
+        )
 
 
 @dataclass

--- a/src/python/arcor2/data/tests/test_common.py
+++ b/src/python/arcor2/data/tests/test_common.py
@@ -1,6 +1,6 @@
 import pytest
 
-from arcor2.data.common import Orientation
+from arcor2.data.common import NamedOrientation, Orientation
 from arcor2.exceptions import Arcor2Exception
 
 
@@ -22,3 +22,14 @@ def test_invalid_orientation() -> None:
 
     with pytest.raises(Arcor2Exception):
         o.as_quaternion()
+
+
+def test_id_stuff() -> None:
+
+    no = NamedOrientation("name", Orientation())
+    assert no.id
+
+    no_copy = no.copy()
+    assert no_copy.id
+
+    assert no.id != no_copy.id

--- a/src/python/arcor2/object_types/abstract.py
+++ b/src/python/arcor2/object_types/abstract.py
@@ -60,7 +60,7 @@ class Generic(metaclass=abc.ABCMeta):
         return parse_docstring(cls.__doc__)["short_description"]
 
     def scene_object(self) -> SceneObject:
-        return SceneObject(self.id, self.name, self.__class__.__name__)
+        return SceneObject(self.name, self.__class__.__name__, id=self.id)
 
     def __repr__(self) -> str:
         return str(self.__dict__)
@@ -93,7 +93,7 @@ class GenericWithPose(Generic):
             scene_service.upsert_collision(self.collision_model, pose)
 
     def scene_object(self) -> SceneObject:
-        return SceneObject(self.id, self.name, self.__class__.__name__, self._pose)
+        return SceneObject(self.name, self.__class__.__name__, self._pose, id=self.id)
 
     @property
     def pose(self) -> Pose:

--- a/src/python/arcor2/parameter_plugins/tests/test_boolean.py
+++ b/src/python/arcor2/parameter_plugins/tests/test_boolean.py
@@ -41,43 +41,42 @@ class TestParametrized:
 
     def test_get_value(self, val: bool) -> None:
 
-        scene = Scene("s1", "s1")
-        obj_id = "TestId"
-        scene.objects.append(SceneObject(obj_id, "test_name", TestObject.__name__))
-        project = Project("p1", "p1", "s1")
-        ap1 = ActionPoint("ap1", "ap1", Position())
+        scene = Scene("s1")
+        obj = SceneObject("test_name", TestObject.__name__)
+        scene.objects.append(obj)
+        project = Project("p1", "s1")
+        ap1 = ActionPoint("ap1", Position())
         project.action_points.append(ap1)
 
         param_name = "bool_param"
         invalid_param_name = "invalid_param"
-        action_id = "ac1"
+        action_name = "ac1"
 
-        ap1.actions.append(
-            Action(
-                action_id,
-                action_id,
-                f"{obj_id}/{TestObject.action.__name__}",
-                [
-                    ActionParameter(param_name, BooleanPlugin.type_name(), BooleanPlugin.value_to_json(val)),
-                    ActionParameter(invalid_param_name, BooleanPlugin.type_name(), json.dumps("non_sense")),
-                ],
-            )
+        act = Action(
+            action_name,
+            f"{obj.id}/{TestObject.action.__name__}",
+            parameters=[
+                ActionParameter(param_name, BooleanPlugin.type_name(), BooleanPlugin.value_to_json(val)),
+                ActionParameter(invalid_param_name, BooleanPlugin.type_name(), json.dumps("non_sense")),
+            ],
         )
+
+        ap1.actions.append(act)
 
         cscene = CachedScene(scene)
         cproject = CachedProject(project)
 
         with pytest.raises(Arcor2Exception):
-            BooleanPlugin.parameter_value({}, cscene, cproject, action_id, "non_sense")
+            BooleanPlugin.parameter_value({}, cscene, cproject, act.id, "non_sense")
 
         with pytest.raises(Arcor2Exception):
             BooleanPlugin.parameter_value({}, cscene, cproject, "non_sense", param_name)
 
         with pytest.raises(ParameterPluginException):
-            BooleanPlugin.parameter_value({}, cscene, cproject, action_id, invalid_param_name)
+            BooleanPlugin.parameter_value({}, cscene, cproject, act.id, invalid_param_name)
 
-        value = BooleanPlugin.parameter_value({}, cscene, cproject, action_id, param_name)
-        exe_value = BooleanPlugin.parameter_execution_value({}, cscene, cproject, action_id, param_name)
+        value = BooleanPlugin.parameter_value({}, cscene, cproject, act.id, param_name)
+        exe_value = BooleanPlugin.parameter_execution_value({}, cscene, cproject, act.id, param_name)
 
         assert value == val
         assert value == exe_value

--- a/src/python/arcor2/parameter_plugins/tests/test_double.py
+++ b/src/python/arcor2/parameter_plugins/tests/test_double.py
@@ -60,42 +60,40 @@ class TestParametrized:
 
     def test_get_value(self, val: float) -> None:
 
-        scene = Scene("s1", "s1")
-        obj_id = "TestId"
-        scene.objects.append(SceneObject(obj_id, "test_name", TestObject.__name__))
-        project = Project("p1", "p1", "s1")
-        ap1 = ActionPoint("ap1", "ap1", Position())
+        scene = Scene("s1")
+        obj = SceneObject("test_name", TestObject.__name__)
+        scene.objects.append(obj)
+        project = Project("p1", "s1")
+        ap1 = ActionPoint("ap1", Position())
         project.action_points.append(ap1)
 
         invalid_param_name = "invalid_param"
-        action_id = "ac1"
 
-        ap1.actions.append(
-            Action(
-                action_id,
-                action_id,
-                f"{obj_id}/{TestObject.action.__name__}",
-                [
-                    ActionParameter(param_name, DoublePlugin.type_name(), DoublePlugin.value_to_json(val)),
-                    ActionParameter(invalid_param_name, DoublePlugin.type_name(), json.dumps("non_sense")),
-                ],
-            )
+        act = Action(
+            "ac1",
+            f"{obj.id}/{TestObject.action.__name__}",
+            parameters=[
+                ActionParameter(param_name, DoublePlugin.type_name(), DoublePlugin.value_to_json(val)),
+                ActionParameter(invalid_param_name, DoublePlugin.type_name(), json.dumps("non_sense")),
+            ],
         )
+
+        ap1.actions.append(act)
 
         cscene = CachedScene(scene)
         cproject = CachedProject(project)
 
         with pytest.raises(Arcor2Exception):
-            DoublePlugin.parameter_value({}, cscene, cproject, action_id, "non_sense")
+            DoublePlugin.parameter_value({}, cscene, cproject, act.id, "non_sense")
 
         with pytest.raises(Arcor2Exception):
             DoublePlugin.parameter_value({}, cscene, cproject, "non_sense", param_name)
 
         with pytest.raises(ParameterPluginException):
-            DoublePlugin.parameter_value({}, cscene, cproject, action_id, invalid_param_name)
+            DoublePlugin.parameter_value({}, cscene, cproject, act.id, invalid_param_name)
 
-        value = DoublePlugin.parameter_value({}, cscene, cproject, action_id, param_name)
-        exe_value = DoublePlugin.parameter_execution_value({}, cscene, cproject, action_id, param_name)
+        value = DoublePlugin.parameter_value({}, cscene, cproject, act.id, param_name)
+        exe_value = DoublePlugin.parameter_execution_value({}, cscene, cproject, act.id, param_name)
 
         assert value == val
         assert value == exe_value

--- a/src/python/arcor2/parameter_plugins/tests/test_image.py
+++ b/src/python/arcor2/parameter_plugins/tests/test_image.py
@@ -43,41 +43,39 @@ def test_get_value() -> None:
     img = Image.new("RGB", (320, 240))
 
     scene = Scene("s1", "s1")
-    obj_id = "TestId"
-    scene.objects.append(SceneObject(obj_id, "test_name", TestObject.__name__))
-    project = Project("p1", "p1", "s1")
-    ap1 = ActionPoint("ap1", "ap1", Position(1, 0, 0))
+    obj = SceneObject("test_name", TestObject.__name__)
+    scene.objects.append(obj)
+    project = Project("p1", "s1")
+    ap1 = ActionPoint("ap1", Position(1, 0, 0))
     project.action_points.append(ap1)
 
     invalid_param_name = "invalid_param"
-    action_id = "ac1"
 
-    ap1.actions.append(
-        Action(
-            action_id,
-            action_id,
-            f"{obj_id}/{TestObject.action.__name__}",
-            [
-                ActionParameter(param_name, ImagePlugin.type_name(), ImagePlugin.value_to_json(img)),
-                ActionParameter(invalid_param_name, ImagePlugin.type_name(), json.dumps("non_sense")),
-            ],
-        )
+    ac1 = Action(
+        "ac1",
+        f"{obj.id}/{TestObject.action.__name__}",
+        parameters=[
+            ActionParameter(param_name, ImagePlugin.type_name(), ImagePlugin.value_to_json(img)),
+            ActionParameter(invalid_param_name, ImagePlugin.type_name(), json.dumps("non_sense")),
+        ],
     )
+
+    ap1.actions.append(ac1)
 
     cscene = CachedScene(scene)
     cproject = CachedProject(project)
 
     with pytest.raises(Arcor2Exception):
-        ImagePlugin.parameter_value(type_defs, cscene, cproject, action_id, "non_sense")
+        ImagePlugin.parameter_value(type_defs, cscene, cproject, ac1.id, "non_sense")
 
     with pytest.raises(Arcor2Exception):
         ImagePlugin.parameter_value(type_defs, cscene, cproject, "non_sense", param_name)
 
     with pytest.raises(ParameterPluginException):
-        ImagePlugin.parameter_value(type_defs, cscene, cproject, action_id, invalid_param_name)
+        ImagePlugin.parameter_value(type_defs, cscene, cproject, ac1.id, invalid_param_name)
 
-    value = ImagePlugin.parameter_value(type_defs, cscene, cproject, action_id, param_name)
-    exe_value = ImagePlugin.parameter_execution_value(type_defs, cscene, cproject, action_id, param_name)
+    value = ImagePlugin.parameter_value(type_defs, cscene, cproject, ac1.id, param_name)
+    exe_value = ImagePlugin.parameter_execution_value(type_defs, cscene, cproject, ac1.id, param_name)
 
     assert value == value
     assert value == exe_value

--- a/src/python/arcor2/parameter_plugins/tests/test_integer.py
+++ b/src/python/arcor2/parameter_plugins/tests/test_integer.py
@@ -59,42 +59,40 @@ class TestParametrized:
 
     def test_get_value(self, val: float) -> None:
 
-        scene = Scene("s1", "s1")
-        obj_id = "TestId"
-        scene.objects.append(SceneObject(obj_id, "test_name", TestObject.__name__))
-        project = Project("p1", "p1", "s1")
-        ap1 = ActionPoint("ap1", "ap1", Position())
+        scene = Scene("s1")
+        obj = SceneObject("test_name", TestObject.__name__)
+        scene.objects.append(obj)
+        project = Project("p1", "s1")
+        ap1 = ActionPoint("ap1", Position())
         project.action_points.append(ap1)
 
         invalid_param_name = "invalid_param"
-        action_id = "ac1"
 
-        ap1.actions.append(
-            Action(
-                action_id,
-                action_id,
-                f"{obj_id}/{TestObject.action.__name__}",
-                [
-                    ActionParameter(param_name, IntegerPlugin.type_name(), IntegerPlugin.value_to_json(val)),
-                    ActionParameter(invalid_param_name, IntegerPlugin.type_name(), json.dumps("non_sense")),
-                ],
-            )
+        ac1 = Action(
+            "ac1",
+            f"{obj.id}/{TestObject.action.__name__}",
+            parameters=[
+                ActionParameter(param_name, IntegerPlugin.type_name(), IntegerPlugin.value_to_json(val)),
+                ActionParameter(invalid_param_name, IntegerPlugin.type_name(), json.dumps("non_sense")),
+            ],
         )
+
+        ap1.actions.append(ac1)
 
         cscene = CachedScene(scene)
         cproject = CachedProject(project)
 
         with pytest.raises(Arcor2Exception):
-            IntegerPlugin.parameter_value({}, cscene, cproject, action_id, "non_sense")
+            IntegerPlugin.parameter_value({}, cscene, cproject, ac1.id, "non_sense")
 
         with pytest.raises(Arcor2Exception):
             IntegerPlugin.parameter_value({}, cscene, cproject, "non_sense", param_name)
 
         with pytest.raises(ParameterPluginException):
-            IntegerPlugin.parameter_value({}, cscene, cproject, action_id, invalid_param_name)
+            IntegerPlugin.parameter_value({}, cscene, cproject, ac1.id, invalid_param_name)
 
-        value = IntegerPlugin.parameter_value({}, cscene, cproject, action_id, param_name)
-        exe_value = IntegerPlugin.parameter_execution_value({}, cscene, cproject, action_id, param_name)
+        value = IntegerPlugin.parameter_value({}, cscene, cproject, ac1.id, param_name)
+        exe_value = IntegerPlugin.parameter_execution_value({}, cscene, cproject, ac1.id, param_name)
 
         assert value == val
         assert value == exe_value

--- a/src/python/arcor2/parameter_plugins/tests/test_string.py
+++ b/src/python/arcor2/parameter_plugins/tests/test_string.py
@@ -44,42 +44,40 @@ class TestParametrized:
 
     def test_get_value(self, val: str) -> None:
 
-        scene = Scene("s1", "s1")
-        obj_id = "TestId"
-        scene.objects.append(SceneObject(obj_id, "test_name", TestObject.__name__))
-        project = Project("p1", "p1", "s1")
-        ap1 = ActionPoint("ap1", "ap1", Position())
+        scene = Scene("s1")
+        obj = SceneObject("test_name", TestObject.__name__)
+        scene.objects.append(obj)
+        project = Project("p1", "s1")
+        ap1 = ActionPoint("ap1", Position())
         project.action_points.append(ap1)
 
         invalid_param_name = "invalid_param"
-        action_id = "ac1"
 
-        ap1.actions.append(
-            Action(
-                action_id,
-                action_id,
-                f"{obj_id}/{TestObject.action.__name__}",
-                [
-                    ActionParameter(param_name, StringPlugin.type_name(), StringPlugin.value_to_json(val)),
-                    ActionParameter(invalid_param_name, StringPlugin.type_name(), json.dumps(666)),
-                ],
-            )
+        ac1 = Action(
+            "ac1",
+            f"{obj.id}/{TestObject.action.__name__}",
+            parameters=[
+                ActionParameter(param_name, StringPlugin.type_name(), StringPlugin.value_to_json(val)),
+                ActionParameter(invalid_param_name, StringPlugin.type_name(), json.dumps(666)),
+            ],
         )
+
+        ap1.actions.append(ac1)
 
         cscene = CachedScene(scene)
         cproject = CachedProject(project)
 
         with pytest.raises(Arcor2Exception):
-            StringPlugin.parameter_value({}, cscene, cproject, action_id, "non_sense")
+            StringPlugin.parameter_value({}, cscene, cproject, ac1.id, "non_sense")
 
         with pytest.raises(Arcor2Exception):
             StringPlugin.parameter_value({}, cscene, cproject, "non_sense", param_name)
 
         with pytest.raises(ParameterPluginException):
-            StringPlugin.parameter_value({}, cscene, cproject, action_id, invalid_param_name)
+            StringPlugin.parameter_value({}, cscene, cproject, ac1.id, invalid_param_name)
 
-        value = StringPlugin.parameter_value({}, cscene, cproject, action_id, param_name)
-        exe_value = StringPlugin.parameter_execution_value({}, cscene, cproject, action_id, param_name)
+        value = StringPlugin.parameter_value({}, cscene, cproject, ac1.id, param_name)
+        exe_value = StringPlugin.parameter_execution_value({}, cscene, cproject, ac1.id, param_name)
 
         assert value == val
         assert value == exe_value

--- a/src/python/arcor2/parameter_plugins/tests/test_string_enum.py
+++ b/src/python/arcor2/parameter_plugins/tests/test_string_enum.py
@@ -66,42 +66,40 @@ class TestParametrized:
 
     def test_get_value(self, val: TestEnum) -> None:
 
-        scene = Scene("s1", "s1")
-        obj_id = "TestId"
-        scene.objects.append(SceneObject(obj_id, "test_name", TestObject.__name__))
-        project = Project("p1", "p1", "s1")
-        ap1 = ActionPoint("ap1", "ap1", Position())
+        scene = Scene("s1")
+        obj = SceneObject("test_name", TestObject.__name__)
+        scene.objects.append(obj)
+        project = Project("p1", "s1")
+        ap1 = ActionPoint("ap1", Position())
         project.action_points.append(ap1)
 
         invalid_param_name = "invalid_param"
-        action_id = "ac1"
 
-        ap1.actions.append(
-            Action(
-                action_id,
-                action_id,
-                f"{obj_id}/{TestObject.action.__name__}",
-                [
-                    ActionParameter(param_name, StringEnumPlugin.type_name(), StringEnumPlugin.value_to_json(val)),
-                    ActionParameter(invalid_param_name, StringEnumPlugin.type_name(), json.dumps("non_sense")),
-                ],
-            )
+        ac1 = Action(
+            "ac1",
+            f"{obj.id}/{TestObject.action.__name__}",
+            parameters=[
+                ActionParameter(param_name, StringEnumPlugin.type_name(), StringEnumPlugin.value_to_json(val)),
+                ActionParameter(invalid_param_name, StringEnumPlugin.type_name(), json.dumps("non_sense")),
+            ],
         )
+
+        ap1.actions.append(ac1)
 
         cscene = CachedScene(scene)
         cproject = CachedProject(project)
 
         with pytest.raises(Arcor2Exception):
-            StringEnumPlugin.parameter_value(type_defs, cscene, cproject, action_id, "non_sense")
+            StringEnumPlugin.parameter_value(type_defs, cscene, cproject, ac1.id, "non_sense")
 
         with pytest.raises(Arcor2Exception):
             StringEnumPlugin.parameter_value(type_defs, cscene, cproject, "non_sense", param_name)
 
         with pytest.raises(ParameterPluginException):
-            StringEnumPlugin.parameter_value(type_defs, cscene, cproject, action_id, invalid_param_name)
+            StringEnumPlugin.parameter_value(type_defs, cscene, cproject, ac1.id, invalid_param_name)
 
-        value = StringEnumPlugin.parameter_value(type_defs, cscene, cproject, action_id, param_name)
-        exe_value = StringEnumPlugin.parameter_execution_value(type_defs, cscene, cproject, action_id, param_name)
+        value = StringEnumPlugin.parameter_value(type_defs, cscene, cproject, ac1.id, param_name)
+        exe_value = StringEnumPlugin.parameter_execution_value(type_defs, cscene, cproject, ac1.id, param_name)
 
         assert value == val
         assert value == exe_value

--- a/src/python/arcor2/tests/test_logic.py
+++ b/src/python/arcor2/tests/test_logic.py
@@ -17,59 +17,65 @@ from arcor2.data.common import (
 from arcor2.exceptions import Arcor2Exception
 from arcor2.logic import check_for_loops
 
+obj = SceneObject("test_name", "Test")
+ac1 = Action("ac1", f"{obj.id}/test", flows=[Flow(outputs=["bool_res"])])
+ac2 = Action("ac2", f"{obj.id}/test", flows=[Flow()])
+ac3 = Action("ac3", f"{obj.id}/test", flows=[Flow()])
+ac4 = Action("ac4", f"{obj.id}/test", flows=[Flow()])
+
 
 @pytest.fixture()
 def scene() -> Scene:
 
     scene = Scene("s1", "s1")
-    scene.objects.append(SceneObject("TestId", "test_name", "Test"))
+    scene.objects.append(obj)
     return scene
 
 
 @pytest.fixture()
 def project() -> UpdateableCachedProject:
 
-    project = Project("p1", "p1", "s1")
-    ap1 = ActionPoint("ap1", "ap1", Position())
+    project = Project("p1", "s1")
+    ap1 = ActionPoint("ap1", Position())
     project.action_points.append(ap1)
 
-    ap1.actions.append(Action("ac1", "ac1", "Test/test", flows=[Flow(outputs=["bool_res"])]))
-    ap1.actions.append(Action("ac2", "ac2", "Test/test", flows=[Flow()]))
-    ap1.actions.append(Action("ac3", "ac3", "Test/test", flows=[Flow()]))
-    ap1.actions.append(Action("ac4", "ac4", "Test/test", flows=[Flow()]))
+    ap1.actions.append(ac1)
+    ap1.actions.append(ac2)
+    ap1.actions.append(ac3)
+    ap1.actions.append(ac4)
     return UpdateableCachedProject(project)
 
 
 def test_project_wo_loop(scene: Scene, project: UpdateableCachedProject) -> None:
 
-    project.upsert_logic_item(LogicItem("l1", LogicItem.START, "ac1"))
-    project.upsert_logic_item(LogicItem("l2", "ac1", "ac2"))
-    project.upsert_logic_item(LogicItem("l3", "ac2", "ac3"))
-    project.upsert_logic_item(LogicItem("l4", "ac3", "ac4"))
-    project.upsert_logic_item(LogicItem("l5", "ac4", LogicItem.END))
+    project.upsert_logic_item(LogicItem(LogicItem.START, ac1.id))
+    project.upsert_logic_item(LogicItem(ac1.id, ac2.id))
+    project.upsert_logic_item(LogicItem(ac2.id, ac3.id))
+    project.upsert_logic_item(LogicItem(ac3.id, ac4.id))
+    project.upsert_logic_item(LogicItem(ac4.id, LogicItem.END))
 
     check_for_loops(project)
 
 
 def test_project_wo_loop_branched_logic(scene: Scene, project: UpdateableCachedProject) -> None:
 
-    project.upsert_logic_item(LogicItem("l1", LogicItem.START, "ac1"))
-    project.upsert_logic_item(LogicItem("l2", "ac1", "ac2", ProjectLogicIf("ac1/default/0", json.dumps(True))))
-    project.upsert_logic_item(LogicItem("l3", "ac1", "ac3", ProjectLogicIf("ac1/default/0", json.dumps(False))))
-    project.upsert_logic_item(LogicItem("l4", "ac2", "ac4"))
-    project.upsert_logic_item(LogicItem("l5", "ac3", "ac4"))
-    project.upsert_logic_item(LogicItem("l6", "ac4", LogicItem.END))
+    project.upsert_logic_item(LogicItem(LogicItem.START, ac1.id))
+    project.upsert_logic_item(LogicItem(ac1.id, ac2.id, ProjectLogicIf(f"{ac1.id}/default/0", json.dumps(True))))
+    project.upsert_logic_item(LogicItem(ac1.id, ac3.id, ProjectLogicIf(f"{ac1.id}/default/0", json.dumps(False))))
+    project.upsert_logic_item(LogicItem(ac2.id, ac4.id))
+    project.upsert_logic_item(LogicItem(ac3.id, ac4.id))
+    project.upsert_logic_item(LogicItem(ac4.id, LogicItem.END))
 
     check_for_loops(project)
 
 
 def test_project_with_loop(scene: Scene, project: UpdateableCachedProject) -> None:
 
-    project.upsert_logic_item(LogicItem("l1", LogicItem.START, "ac1"))
-    project.upsert_logic_item(LogicItem("l2", "ac1", "ac2"))
-    project.upsert_logic_item(LogicItem("l3", "ac2", "ac3"))
-    project.upsert_logic_item(LogicItem("l4", "ac3", "ac4"))
-    project.upsert_logic_item(LogicItem("l5", "ac4", "ac1"))
+    project.upsert_logic_item(LogicItem(LogicItem.START, ac1.id))
+    project.upsert_logic_item(LogicItem(ac1.id, ac2.id))
+    project.upsert_logic_item(LogicItem(ac2.id, ac3.id))
+    project.upsert_logic_item(LogicItem(ac3.id, ac4.id))
+    project.upsert_logic_item(LogicItem(ac4.id, ac1.id))
 
     with pytest.raises(Arcor2Exception):
         check_for_loops(project)
@@ -77,14 +83,14 @@ def test_project_with_loop(scene: Scene, project: UpdateableCachedProject) -> No
 
 def test_project_unfinished_logic_wo_loop(scene: Scene, project: UpdateableCachedProject) -> None:
 
-    project.upsert_logic_item(LogicItem("l1", "ac1", "ac2"))
-    check_for_loops(project, "ac1")
+    project.upsert_logic_item(LogicItem(ac1.id, ac2.id))
+    check_for_loops(project, ac1.id)
 
 
 def test_project_unfinished_logic_with_loop(scene: Scene, project: UpdateableCachedProject) -> None:
 
-    project.upsert_logic_item(LogicItem("l1", "ac1", "ac2"))
-    project.upsert_logic_item(LogicItem("l2", "ac2", "ac1"))
+    project.upsert_logic_item(LogicItem(ac1.id, ac2.id))
+    project.upsert_logic_item(LogicItem(ac2.id, ac1.id))
 
     with pytest.raises(Arcor2Exception):
-        check_for_loops(project, "ac1")
+        check_for_loops(project, ac1.id)

--- a/src/python/arcor2/tests/test_transformations.py
+++ b/src/python/arcor2/tests/test_transformations.py
@@ -114,14 +114,17 @@ def test_make_orientation_rel_and_then_again_abs_2() -> None:
 
 def test_make_relative_ap_global_and_relative_again() -> None:
 
-    scene = Scene("s1", "s1")
-    scene.objects.append(SceneObject("so1", "so1", "WhatEver", Pose(Position(3, 0, 0), Orientation())))
+    scene = Scene("s1")
+    so1 = SceneObject("so1", "WhatEver", Pose(Position(3, 0, 0), Orientation()))
+    scene.objects.append(so1)
     cached_scene = CachedScene(scene)
 
-    project = Project("p1", "p1", "s1")
-    project.action_points.append(ActionPoint("ap1", "ap1", Position(-1, 0, 0), parent="so1"))
-    project.action_points.append(ActionPoint("ap2", "ap2", Position(-1, 0, 0), parent="ap1"))
-    ap3 = ActionPoint("ap3", "ap3", Position(-1, 0, 0), parent="ap2")
+    project = Project("p1", scene.id)
+    ap1 = ActionPoint("ap1", Position(-1, 0, 0), parent=so1.id)
+    project.action_points.append(ap1)
+    ap2 = ActionPoint("ap2", Position(-1, 0, 0), parent=ap1.id)
+    project.action_points.append(ap2)
+    ap3 = ActionPoint("ap3", Position(-1, 0, 0), parent=ap2.id)
     project.action_points.append(ap3)
 
     cached_project = CachedProject(project)
@@ -131,9 +134,9 @@ def test_make_relative_ap_global_and_relative_again() -> None:
     assert ap3.parent is None
     assert ap3.position.x == 0.0
 
-    make_global_ap_relative(cached_scene, cached_project, ap3, "ap2")
+    make_global_ap_relative(cached_scene, cached_project, ap3, ap2.id)
 
-    assert ap3.parent == "ap2"
+    assert ap3.parent == ap2.id
     assert ap3.position.x == -1
 
     ap3.parent = "something_unknown"

--- a/src/python/arcor2_arserver/execution.py
+++ b/src/python/arcor2_arserver/execution.py
@@ -72,7 +72,7 @@ async def build_and_upload_package(project_id: str, package_name: str) -> str:
     :return: generated package ID.
     """
 
-    package_id = common.uid()
+    package_id = common.uid("pkg")
 
     # call build service
     # TODO store data in memory

--- a/src/python/arcor2_arserver/rpc/scene.py
+++ b/src/python/arcor2_arserver/rpc/scene.py
@@ -63,7 +63,7 @@ async def managed_scene(scene_id: str, make_copy: bool = False) -> AsyncGenerato
         scene = UpdateableCachedScene(await storage.get_scene(scene_id))
 
     if make_copy:
-        scene.id = common.uid()
+        scene.id = common.Scene.uid()
 
     try:
         yield scene
@@ -94,7 +94,7 @@ async def new_scene_cb(req: srpc.s.NewScene.Request, ui: WsClient) -> None:
         return None
 
     await get_object_types()  # TODO not ideal, may take quite long time
-    glob.SCENE = UpdateableCachedScene(common.Scene(common.uid(), req.args.name, desc=req.args.desc))
+    glob.SCENE = UpdateableCachedScene(common.Scene(req.args.name, desc=req.args.desc))
     asyncio.ensure_future(notif.broadcast_event(sevts.s.OpenScene(sevts.s.OpenScene.Data(glob.SCENE.scene))))
     asyncio.ensure_future(scene_srv.delete_all_collisions())  # just for sure
     return None
@@ -171,7 +171,7 @@ async def add_object_to_scene_cb(req: srpc.s.AddObjectToScene.Request, ui: WsCli
 
     can_modify_scene()
 
-    obj = common.SceneObject(common.uid(), req.args.name, req.args.type, req.args.pose, req.args.parameters)
+    obj = common.SceneObject(req.args.name, req.args.type, req.args.pose, req.args.parameters)
 
     await add_object_to_scene(obj, dry_run=req.dry_run)
 

--- a/src/python/arcor2_arserver/tests/test_openapi.py
+++ b/src/python/arcor2_arserver/tests/test_openapi.py
@@ -1,0 +1,18 @@
+import os
+import tempfile
+from subprocess import check_output
+
+import yaml
+from openapi_spec_validator import validate_spec
+
+
+def test_arserver_openapi() -> None:
+
+    with tempfile.TemporaryDirectory() as tmp:
+
+        my_env = os.environ.copy()
+        my_env["ARCOR2_DATA_PATH"] = tmp
+
+        validate_spec(
+            yaml.full_load(check_output(["./src.python.arcor2_arserver.scripts/arserver.pex", "--openapi"], env=my_env))
+        )

--- a/src/python/arcor2_kinali/examples/main_script_full_manual.py
+++ b/src/python/arcor2_kinali/examples/main_script_full_manual.py
@@ -23,17 +23,17 @@ from arcor2_kinali.object_types.statistic import Statistic
 def main() -> None:
 
     # robots
-    aubo = Aubo(uid(), "Whatever", Pose(), RobotSettings("http://127.0.0.1:13000", "aubo"))
-    simatic = Aubo(uid(), "Whatever", Pose(), RobotSettings("http://127.0.0.1:13001", "simatic"))
+    aubo = Aubo(uid("rbt"), "Whatever", Pose(), RobotSettings("http://127.0.0.1:13000", "aubo"))
+    simatic = Aubo(uid("rbt"), "Whatever", Pose(), RobotSettings("http://127.0.0.1:13001", "simatic"))
 
     # objects with pose, with 'System' and 'Configurations' controllers
-    barcode = Barcode(uid(), "Whatever", Pose(), settings=Settings("http://127.0.0.1:14000", "simulator"))
-    search = Search(uid(), "Whatever", Pose(), settings=Settings("http://127.0.0.1:12000", "simulator"))
-    ict = Ict(uid(), "Whatever", Pose(), settings=Settings("http://127.0.0.1:19000", "simulator"))
+    barcode = Barcode(uid("srv"), "Whatever", Pose(), settings=Settings("http://127.0.0.1:14000", "simulator"))
+    search = Search(uid("srv"), "Whatever", Pose(), settings=Settings("http://127.0.0.1:12000", "simulator"))
+    ict = Ict(uid("srv"), "Whatever", Pose(), settings=Settings("http://127.0.0.1:19000", "simulator"))
 
     # objects without pose, without 'System' and 'Configurations' controllers
-    interaction = Interaction(uid(), "Whatever", SimpleSettings("http://127.0.0.1:17000"))
-    statistic = Statistic(uid(), "Whatever", SimpleSettings("http://127.0.0.1:16000"))
+    interaction = Interaction(uid("srv"), "Whatever", SimpleSettings("http://127.0.0.1:17000"))
+    statistic = Statistic(uid("srv"), "Whatever", SimpleSettings("http://127.0.0.1:16000"))
 
     # Add @action decorator to all actions of each object using patch_object_actions.
     # It has to be called exactly once for each type!
@@ -52,7 +52,7 @@ def main() -> None:
     scene_service.start()  # this is normally done by auto-generated Resources class
 
     aubo.move("suction", Pose(), MoveTypeEnum.SIMPLE, safe=False)
-    simatic.set_joints(ProjectRobotJoints("", "", "", [Joint("x", 0), Joint("y", 0)]), MoveTypeEnum.SIMPLE)
+    simatic.set_joints(ProjectRobotJoints("", "", [Joint("x", 0), Joint("y", 0)]), MoveTypeEnum.SIMPLE)
     barcode.scan()
     search.set_search_parameters(SearchEngineParameters(search_log_level=SearchLogLevel(LogLevel.DEBUG)))
     search.grab_image()

--- a/src/python/arcor2_kinali/examples/main_script_with_resources.py
+++ b/src/python/arcor2_kinali/examples/main_script_with_resources.py
@@ -12,7 +12,7 @@ from arcor2_kinali.object_types.statistic import Statistic
 
 def main(res: Resources) -> None:
 
-    statistic = Statistic(uid(), "Whatever", SimpleSettings("http://127.0.0.1:16000"))
+    statistic = Statistic(uid("obj"), "Whatever", SimpleSettings("http://127.0.0.1:16000"))
     statistic.add_value(res.project.id, "value_name", 1.0, an="action_name")
 
 

--- a/src/python/arcor2_kinali/object_types/abstract_robot.py
+++ b/src/python/arcor2_kinali/object_types/abstract_robot.py
@@ -61,7 +61,7 @@ class AbstractRobot(Robot):
         rest.call(rest.Method.PUT, f"{self.settings.url}/system/reset")
 
     def move_to_joints(self, target_joints: List[Joint], speed: float, safe: bool = True) -> None:
-        self.set_joints(ProjectRobotJoints("", "", "", target_joints), MoveTypeEnum.SIMPLE, speed, safe=safe)
+        self.set_joints(ProjectRobotJoints("", "", target_joints), MoveTypeEnum.SIMPLE, speed, safe=safe)
 
     # --- Grippers Controller ------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
- Classes that rely on unique IDs (uuid) now generate those IDs on their own.
- If necessary, ID can be still provided.
- IDs are prefixed so developers can easily check the type of an object from its ID.