### PR TITLE
feat: get rid of horast

### DIFF
--- a/3rdparty/constraints.txt
+++ b/3rdparty/constraints.txt
@@ -1,9 +1,8 @@
+astunparse==1.6.3  # this is not necessary once switched to Python 3.9 (ast.unparse is there)
 aiologger==0.6.0
 aiorun==2020.12.1
 apispec-webframeworks==0.5.2
 apispec==4.0.0
-asttokens==2.0.4
-astunparse==1.6.3
 attrs==20.3.0
 autopep8==1.5.6
 certifi==2020.12.5
@@ -16,7 +15,6 @@ flask-swagger-ui==3.36.0
 Flask==1.1.1
 gitdb==4.0.5
 GitPython==3.1.14
-horast-rereleased==0.4.3
 chardet==4.0.0
 idna==2.5
 iniconfig==1.1.1
@@ -59,11 +57,8 @@ setuptools==54.1.2
 six==1.15.0
 smmap==3.0.4
 sqlitedict==1.7.0
-static-typing==0.2.7
 toml==0.10.2
 trimesh==3.9.9
-typed-astunparse==2.1.4
-typed-ast==1.4.2
 typing-extensions==3.7.4.3
 typing-inspect==0.6.0
 urdfpy==0.0.22

--- a/3rdparty/requirements.txt
+++ b/3rdparty/requirements.txt
@@ -1,3 +1,4 @@
+astunparse==1.6.3  # this is not necessary once switched to Python 3.9 (ast.unparse is there)
 aiologger==0.6.0
 aiorun==2020.12.1
 apispec-webframeworks[tests]==0.5.2  # "tests" is used just to get dependency on Flask (which is missing otherwise)
@@ -8,7 +9,6 @@ dataclasses-jsonschema[fast-validation,apispec]==2.14.1
 flask_cors==3.0.10
 flask-swagger-ui==3.36.0
 Flask==1.1.1  # can't be updated because of apispec-webframeworks
-horast-rereleased==0.4.3
 lru-dict==1.1.7
 numpy-quaternion==2021.3.17.16.51.43
 numpy==1.20.1
@@ -26,9 +26,6 @@ pyserial==3.5
 PyYAML==5.4.1
 requests==2.25.1
 sqlitedict==1.7.0
-static-typing==0.2.7
-typed-astunparse==2.1.4
-typed-ast==1.4.2
 typing-inspect==0.6.0
 urdfpy==0.0.22
 websocket-client==0.58.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,6 +18,9 @@ check_untyped_defs = True
 # TODO enable this once numpy 1.21.0 is out
 # plugins = numpy.typing.mypy_plugin
 
+[mypy-astunparse]
+ignore_missing_imports = True
+
 [mypy-pytest]
 ignore_missing_imports = True
 
@@ -55,9 +58,6 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-typing_inspect]
-ignore_missing_imports = True
-
-[mypy-pydobot]
 ignore_missing_imports = True
 
 [mypy-autopep8]

--- a/src/python/arcor2/object_types/utils.py
+++ b/src/python/arcor2/object_types/utils.py
@@ -1,3 +1,4 @@
+import ast
 import inspect
 import json
 import os
@@ -7,7 +8,6 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Ty
 
 import typing_inspect
 from dataclasses_jsonschema import JsonSchemaMixin, ValidationError
-from typed_ast.ast3 import Name
 
 import arcor2
 from arcor2.data.common import ActionMetadata, Parameter
@@ -173,7 +173,7 @@ def base_from_source(source: str, cls_name: str) -> Optional[str]:
 
     base_name = cls_def.bases[-1]  # allow usage of mixins e.g. class MyType(mixin, Generic)
 
-    assert isinstance(base_name, Name)
+    assert isinstance(base_name, ast.Name)
     return base_name.id
 
 

--- a/src/python/arcor2/parameter_plugins/base.py
+++ b/src/python/arcor2/parameter_plugins/base.py
@@ -1,11 +1,11 @@
 import abc
+import ast
 import copy
 import json
+from ast import AST
 from typing import Any, Callable, List, NamedTuple, Optional
 
 import humps
-from typed_ast import ast3 as ast
-from typed_ast.ast3 import AST
 
 from arcor2.cached import CachedProject as CProject
 from arcor2.cached import CachedScene as CScene

--- a/src/python/arcor2/parameter_plugins/boolean.py
+++ b/src/python/arcor2/parameter_plugins/boolean.py
@@ -1,6 +1,5 @@
+from ast import NameConstant
 from typing import Any, List
-
-from typed_ast.ast3 import NameConstant
 
 from arcor2.cached import CachedProject as CProject
 from arcor2.cached import CachedScene as CScene
@@ -34,7 +33,9 @@ class BooleanPlugin(ParameterPlugin):
     def parameter_ast(
         cls, type_defs: TypesDict, scene: CScene, project: CProject, action_id: str, parameter_id: str
     ) -> NameConstant:
-        return NameConstant(value=cls.parameter_execution_value(type_defs, scene, project, action_id, parameter_id))
+        return NameConstant(
+            value=cls.parameter_execution_value(type_defs, scene, project, action_id, parameter_id), kind=None
+        )
 
 
 class BooleanListPlugin(ListParameterPlugin):

--- a/src/python/arcor2/parameter_plugins/double.py
+++ b/src/python/arcor2/parameter_plugins/double.py
@@ -1,7 +1,5 @@
+import ast
 from typing import Any, Callable, List
-
-from typed_ast import ast3 as ast
-from typed_ast.ast3 import Num
 
 from arcor2.cached import CachedProject as CProject
 from arcor2.cached import CachedScene as CScene
@@ -38,8 +36,8 @@ class DoublePlugin(ParameterPlugin):
     @classmethod
     def parameter_ast(
         cls, type_defs: TypesDict, scene: CScene, project: CProject, action_id: str, parameter_id: str
-    ) -> Num:
-        return Num(n=cls.parameter_execution_value(type_defs, scene, project, action_id, parameter_id))
+    ) -> ast.Num:
+        return ast.Num(n=cls.parameter_execution_value(type_defs, scene, project, action_id, parameter_id), kind=None)
 
 
 class DoubleListPlugin(ListParameterPlugin):

--- a/src/python/arcor2/parameter_plugins/image.py
+++ b/src/python/arcor2/parameter_plugins/image.py
@@ -1,7 +1,7 @@
+from ast import stmt
 from typing import Any
 
 from PIL.Image import Image
-from typed_ast.ast3 import stmt
 
 from arcor2.cached import CachedProject as CProject
 from arcor2.cached import CachedScene as CScene

--- a/src/python/arcor2/parameter_plugins/integer.py
+++ b/src/python/arcor2/parameter_plugins/integer.py
@@ -1,9 +1,9 @@
+import ast
+from ast import Num
 from dataclasses import dataclass
 from typing import Any, Callable, List, Tuple, Type
 
 from dataclasses_jsonschema import JsonSchemaMixin
-from typed_ast import ast3 as ast
-from typed_ast.ast3 import Num
 
 from arcor2.cached import CachedProject as CProject
 from arcor2.cached import CachedScene as CScene
@@ -101,7 +101,7 @@ class IntegerPlugin(ParameterPlugin):
     def parameter_ast(
         cls, type_defs: TypesDict, scene: CScene, project: CProject, action_id: str, parameter_id: str
     ) -> Num:
-        return Num(n=cls.parameter_execution_value(type_defs, scene, project, action_id, parameter_id))
+        return Num(n=cls.parameter_execution_value(type_defs, scene, project, action_id, parameter_id), kind=None)
 
 
 class IntegerListPlugin(ListParameterPlugin):

--- a/src/python/arcor2/parameter_plugins/integer_enum.py
+++ b/src/python/arcor2/parameter_plugins/integer_enum.py
@@ -1,12 +1,12 @@
+import ast
 import inspect
 import json
+from ast import Attribute, Load, Name
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, List, Optional, Set, get_type_hints
 
 from dataclasses_jsonschema import JsonSchemaMixin
-from typed_ast import ast3 as ast
-from typed_ast.ast3 import Attribute, Load, Name
 
 from arcor2.cached import CachedProject as CProject
 from arcor2.cached import CachedScene as CScene

--- a/src/python/arcor2/parameter_plugins/joints.py
+++ b/src/python/arcor2/parameter_plugins/joints.py
@@ -1,6 +1,5 @@
+from ast import Attribute, Load, Name
 from typing import Any
-
-from typed_ast.ast3 import Attribute, Load, Name
 
 from arcor2.cached import CachedProject as CProject
 from arcor2.cached import CachedScene as CScene

--- a/src/python/arcor2/parameter_plugins/pose.py
+++ b/src/python/arcor2/parameter_plugins/pose.py
@@ -1,8 +1,7 @@
 import copy
 import json
+from ast import Attribute, Load, Name
 from typing import Any, List
-
-from typed_ast.ast3 import Attribute, Load, Name
 
 from arcor2 import transformations as tr
 from arcor2.cached import CachedProject as CProject

--- a/src/python/arcor2/parameter_plugins/relative_pose.py
+++ b/src/python/arcor2/parameter_plugins/relative_pose.py
@@ -1,7 +1,7 @@
+from ast import Call, Load, Name, Num
 from typing import Any, List, Optional
 
 from dataclasses_jsonschema import ValidationError
-from typed_ast.ast3 import Call, Load, Name, Num
 
 import arcor2.data.common
 from arcor2.cached import CachedProject as CProject
@@ -41,16 +41,20 @@ class RelativePosePlugin(ParameterPlugin):
             args=[
                 Call(
                     func=Name(id=Position.__name__, ctx=Load()),
-                    args=[Num(n=val.position.x), Num(n=val.position.y), Num(n=val.position.z)],
+                    args=[
+                        Num(n=val.position.x, kind=None),
+                        Num(n=val.position.y, kind=None),
+                        Num(n=val.position.z, kind=None),
+                    ],
                     keywords=[],
                 ),
                 Call(
                     func=Name(id=Orientation.__name__, ctx=Load()),
                     args=[
-                        Num(n=val.orientation.x),
-                        Num(n=val.orientation.y),
-                        Num(n=val.orientation.z),
-                        Num(n=val.orientation.w),
+                        Num(n=val.orientation.x, kind=None),
+                        Num(n=val.orientation.y, kind=None),
+                        Num(n=val.orientation.z, kind=None),
+                        Num(n=val.orientation.w, kind=None),
                     ],
                     keywords=[],
                 ),

--- a/src/python/arcor2/parameter_plugins/string.py
+++ b/src/python/arcor2/parameter_plugins/string.py
@@ -1,6 +1,5 @@
+from ast import Str
 from typing import Any, List
-
-from typed_ast.ast3 import Str
 
 from arcor2.cached import CachedProject as CProject
 from arcor2.cached import CachedScene as CScene

--- a/src/python/arcor2/source/__init__.py
+++ b/src/python/arcor2/source/__init__.py
@@ -1,10 +1,6 @@
-import static_typing as st
-import typed_ast.ast3
-
 from arcor2.exceptions import Arcor2Exception
 
 SCRIPT_HEADER = "#!/usr/bin/env python3\n" "# -*- coding: utf-8 -*-\n\n"
-validator = st.ast_manipulation.AstValidator[typed_ast.ast3](mode="strict")
 
 
 class SourceException(Arcor2Exception):

--- a/src/python/arcor2/source/utils.py
+++ b/src/python/arcor2/source/utils.py
@@ -1,11 +1,8 @@
+import ast
 import importlib
 import inspect
-from typing import List, Optional, Type, Union
-
-import autopep8
-import horast
-import typed_astunparse
-from typed_ast.ast3 import (
+import sys
+from ast import (
     AST,
     Assert,
     Assign,
@@ -26,6 +23,10 @@ from typed_ast.ast3 import (
     alias,
     fix_missing_locations,
 )
+from typing import List, Optional, Type, Union
+
+import astunparse  # TODO this is not necessary once switched to Python 3.9 (ast.unparse is there)
+import autopep8
 
 from arcor2.source import SourceException
 
@@ -33,7 +34,7 @@ from arcor2.source import SourceException
 def parse(source: str) -> AST:
 
     try:
-        return horast.parse(source)
+        return ast.parse(source, feature_version=sys.version_info[0:2])
     except (AssertionError, NotImplementedError, SyntaxError, ValueError) as e:
         raise SourceException("Failed to parse the code.") from e
 
@@ -199,11 +200,11 @@ def get_name_attr(name: str, attr: str, ctx: Union[Type[Load], Type[Store]] = Lo
 def tree_to_str(tree: AST) -> str:
 
     fix_missing_locations(tree)
-    return autopep8.fix_code(horast.unparse(tree), options={"aggressive": 1, "max_line_length": 120})
+    return autopep8.fix_code(astunparse.unparse(tree), options={"aggressive": 1, "max_line_length": 120})
 
 
 def dump(tree: Module) -> str:
-    return typed_astunparse.dump(tree)
+    return astunparse.dump(tree)
 
 
 def find_raises(tree: FunctionDef) -> List[Raise]:

--- a/src/python/arcor2_arserver/object_types/data.py
+++ b/src/python/arcor2_arserver/object_types/data.py
@@ -1,7 +1,6 @@
+from ast import AST
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Type
-
-from typed_ast.ast3 import AST
 
 from arcor2.object_types.abstract import Generic
 from arcor2_arserver_data.objects import ObjectAction, ObjectTypeMeta

--- a/src/python/arcor2_arserver/object_types/source.py
+++ b/src/python/arcor2_arserver/object_types/source.py
@@ -1,5 +1,6 @@
+from ast import AST, Assign, Call, ClassDef, ImportFrom, Module, Name, NameConstant, Pass, Store, alias
+
 import humps
-from typed_ast.ast3 import AST, Assign, Call, ClassDef, ImportFrom, Module, Name, NameConstant, Pass, Store, alias
 
 import arcor2.object_types
 from arcor2.exceptions import Arcor2NotImplemented
@@ -27,7 +28,13 @@ def new_object_type(parent: ObjectTypeMeta, child: ObjectTypeMeta) -> AST:
         name=child.type,
         bases=[get_name(parent.type)],
         keywords=[],
-        body=[Assign(targets=[Name(id="_ABSTRACT", ctx=Store())], value=NameConstant(value=False), type_comment=None)],
+        body=[
+            Assign(
+                targets=[Name(id="_ABSTRACT", ctx=Store())],
+                value=NameConstant(value=False, kind=None),
+                type_comment=None,
+            )
+        ],
         decorator_list=[],
     )
 

--- a/src/python/arcor2_arserver/object_types/utils.py
+++ b/src/python/arcor2_arserver/object_types/utils.py
@@ -1,12 +1,12 @@
 import copy
 import inspect
 import os
+from ast import AST
 from typing import Dict, List, Optional, Type, get_type_hints
 
 import humps
 import typing_inspect
 from dataclasses_jsonschema import JsonSchemaMixin
-from typed_ast.ast3 import AST
 
 from arcor2.data.common import ActionMetadata
 from arcor2.data.object_type import ParameterMeta

--- a/src/python/arcor2_arserver/robot.py
+++ b/src/python/arcor2_arserver/robot.py
@@ -1,7 +1,6 @@
 import inspect
+from ast import AST
 from typing import List, Optional, Set, Type
-
-from typed_ast.ast3 import AST
 
 import arcor2.helpers as hlp
 from arcor2.data import common

--- a/src/python/arcor2_build/source/logic.py
+++ b/src/python/arcor2_build/source/logic.py
@@ -1,9 +1,6 @@
 import logging
 import os
-from typing import Dict, List, Optional, Set, Union
-
-import humps
-from typed_ast.ast3 import (
+from ast import (
     AST,
     Assign,
     Compare,
@@ -23,6 +20,9 @@ from typed_ast.ast3 import (
     expr,
     keyword,
 )
+from typing import Dict, List, Optional, Set, Union
+
+import humps
 
 from arcor2.cached import CachedProject as CProject
 from arcor2.cached import CachedScene as CScene
@@ -61,9 +61,9 @@ def program_src(type_defs: TypesDict, project: CProject, scene: CScene, add_logi
         aval: Optional[expr] = None
 
         if isinstance(val, (int, float)):
-            aval = Num(n=val)
+            aval = Num(n=val, kind=None)
         elif isinstance(val, bool):
-            aval = NameConstant(value=val)
+            aval = NameConstant(value=val, kind=None)
         elif isinstance(val, str):
             aval = Str(s=val, kind="")
 
@@ -229,7 +229,7 @@ def add_logic_to_loop(type_defs: TypesDict, tree: Module, scene: CScene, project
                 import json
 
                 condition_value = json.loads(output.condition.value)
-                comp = NameConstant(value=condition_value)
+                comp = NameConstant(value=condition_value, kind=None)
                 what = output.condition.parse_what()
                 output_name = project.action(what.action_id).flow(what.flow_name).outputs[what.output_index]
 

--- a/src/python/arcor2_build/source/object_types.py
+++ b/src/python/arcor2_build/source/object_types.py
@@ -1,4 +1,4 @@
-from typed_ast.ast3 import AnnAssign, Index, Load, Name, Store, Str, Subscript
+from ast import AnnAssign, Index, Load, Name, Store, Str, Subscript
 
 from arcor2.exceptions import Arcor2Exception
 from arcor2.helpers import is_valid_identifier, is_valid_type

--- a/src/python/arcor2_build/source/utils.py
+++ b/src/python/arcor2_build/source/utils.py
@@ -1,8 +1,5 @@
 import copy
-from typing import List, Union
-
-import humps
-from typed_ast.ast3 import (
+from ast import (
     AnnAssign,
     Assign,
     Attribute,
@@ -32,6 +29,9 @@ from typed_ast.ast3 import (
     stmt,
     withitem,
 )
+from typing import List, Union
+
+import humps
 
 import arcor2.data.common
 import arcor2.exceptions.runtime
@@ -72,7 +72,7 @@ def empty_script_tree(project_id: str, add_main_loop: bool = True) -> Module:
     ]
 
     if add_main_loop:
-        main_body.append(While(test=NameConstant(value=True), body=[Pass()], orelse=[]))
+        main_body.append(While(test=NameConstant(value=True, kind=None), body=[Pass()], orelse=[]))
     else:
         """put there "pass" in order to make code valid even if there is no
         other statement (e.g. no object from resources)"""
@@ -94,7 +94,7 @@ def empty_script_tree(project_id: str, add_main_loop: bool = True) -> Module:
                 ),
                 body=main_body,
                 decorator_list=[],
-                returns=NameConstant(value=None),
+                returns=NameConstant(value=None, kind=None),
                 type_comment=None,
             ),
             If(


### PR DESCRIPTION
- `horast` was used as it does not discard comments.
- It seems to be abandoned now.
- Default `ast` seems to be 1000 times faster at parsing the code.