### PR TITLE
Change rest call for inverse kinematics

### DIFF
--- a/src/python/arcor2_kinali/CHANGELOG.md
+++ b/src/python/arcor2_kinali/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Class `AbstractRobot` updated for Robot 0.10.0
+- Class `Aubo` (inverse_kinematics) updated for Robot 0.11.0
 
 ## [0.12.1] - 2021-03-15
 

--- a/src/python/arcor2_kinali/object_types/aubo.py
+++ b/src/python/arcor2_kinali/object_types/aubo.py
@@ -26,6 +26,13 @@ class MoveRelativeJointsParameters(JsonSchemaMixin):
     orientation: Orientation
 
 
+@dataclass
+class IKPoseJointsParameters(JsonSchemaMixin):
+
+    pose: Pose
+    joints: List[Joint]
+
+
 class Aubo(AbstractRobot):
     """REST interface to the robot service (0.7.0)."""
 
@@ -189,11 +196,13 @@ class Aubo(AbstractRobot):
         if start_joints is None:
             start_joints = self.robot_joints()
 
+        body = IKPoseJointsParameters(pose, start_joints)
+
         return rest.call(
             rest.Method.PUT,
             f"{self.settings.url}/endEffectors/{end_effector_id}/inverseKinematics",
-            params={"startJoints": [joint.to_dict() for joint in start_joints], "avoidCollisions": avoid_collisions},
-            body=pose,
+            params={"avoidCollisions": avoid_collisions},
+            body=body,
             list_return_type=Joint,
         )
 


### PR DESCRIPTION
Changed the rest api call for `inverse_kinematics` for new [Robot](https://gitlab.com/kinalisoft/test-it-off/robot). Comitted as `fix` since there are not API breaking changes for arcor.

- ran formatter and linter, failed to run the typecheck and tests.