### PR TITLE
RPC locking

### DIFF
--- a/3rdparty/constraints.txt
+++ b/3rdparty/constraints.txt
@@ -94,6 +94,7 @@ pyrender==0.1.45
 pyrsistent==0.17.3
 pyserial==3.5
 pytest==6.2.3
+pytest-asyncio==0.14.0
 pytest-randomly==3.7.0
 pytest-repeat==0.9.1
 python-dateutil==2.8.1

--- a/3rdparty/requirements.txt
+++ b/3rdparty/requirements.txt
@@ -19,6 +19,7 @@ packaging==20.9
 Pillow==8.2.0
 pyhumps==1.6.1
 pyk4a==1.2.3
+pytest-asyncio==0.14.0
 pytest-randomly==3.7.0
 pytest-repeat==0.9.1
 pytest==6.2.3

--- a/src/python/arcor2_arserver/BUILD
+++ b/src/python/arcor2_arserver/BUILD
@@ -3,6 +3,7 @@ arcor2_python_distribution(
     description="ARCOR2 ARServer",
     dependencies=[
         "src/python/arcor2_arserver/clients",
+        "src/python/arcor2_arserver/lock",
         "src/python/arcor2_arserver/object_types",
         "src/python/arcor2_arserver/rpc"
     ],

--- a/src/python/arcor2_arserver/decorators.py
+++ b/src/python/arcor2_arserver/decorators.py
@@ -1,8 +1,10 @@
 import functools
-from typing import Any, Callable, Coroutine, TypeVar, cast
+from asyncio import sleep
+from typing import Any, Callable, Coroutine, Type, TypeVar, cast
 
 from arcor2.exceptions import Arcor2Exception
 from arcor2_arserver import globals as glob
+from arcor2_arserver.lock.exceptions import LockingException
 
 F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, Any]])
 
@@ -11,7 +13,7 @@ def no_scene(coro: F) -> F:
     @functools.wraps(coro)
     async def async_wrapper(*args, **kwargs) -> Any:
 
-        if glob.SCENE:
+        if glob.LOCK.scene:
             raise Arcor2Exception("Scene has to be closed first.")
         return await coro(*args, **kwargs)
 
@@ -22,7 +24,7 @@ def scene_needed(coro: F) -> F:
     @functools.wraps(coro)
     async def async_wrapper(*args, **kwargs) -> Any:
 
-        if glob.SCENE is None or not glob.SCENE.id:
+        if glob.LOCK.scene is None or not glob.LOCK.scene.id:
             raise Arcor2Exception("Scene not opened or has invalid id.")
         return await coro(*args, **kwargs)
 
@@ -32,7 +34,7 @@ def scene_needed(coro: F) -> F:
 def no_project(coro: F) -> F:
     @functools.wraps(coro)
     async def async_wrapper(*args, **kwargs) -> Any:
-        if glob.PROJECT:
+        if glob.LOCK.project:
             raise Arcor2Exception("Not available during project editing.")
         return await coro(*args, **kwargs)
 
@@ -43,8 +45,42 @@ def project_needed(coro: F) -> F:
     @functools.wraps(coro)
     async def async_wrapper(*args, **kwargs) -> Any:
 
-        if glob.PROJECT is None or not glob.PROJECT.id:
+        if glob.LOCK.project is None or not glob.LOCK.project.id:
             raise Arcor2Exception("Project not opened or has invalid id.")
         return await coro(*args, **kwargs)
 
     return cast(F, async_wrapper)
+
+
+def retry(exc: Type[Exception] = LockingException, tries: int = 1, delay: float = 0) -> Callable:
+    """Retry decorator.
+
+    :param exc: Exception or tuple of exceptions to catch
+    :param tries: number of attempts
+    :param delay: delay between attempts
+    :return:
+    """
+
+    async def _retry_call(_tries: int, coro: F, *args, **kwargs) -> Any:
+        """
+        Internal part of retry decorator - handles exceptions, delay and tries
+        """
+        while _tries:
+            try:
+                return await coro(*args, **kwargs)
+            except exc:
+                _tries -= 1
+                if _tries == 0:
+                    raise
+
+                if delay > 0:
+                    await sleep(delay)
+
+    def _retry(coro: F) -> F:
+        @functools.wraps(coro)
+        async def async_wrapper(*fargs, **fkwargs) -> Any:
+            return await _retry_call(tries, coro, *fargs, **fkwargs)
+
+        return cast(F, async_wrapper)
+
+    return _retry

--- a/src/python/arcor2_arserver/execution.py
+++ b/src/python/arcor2_arserver/execution.py
@@ -35,8 +35,8 @@ MANAGER_RPC_RESPONSES: Dict[int, RespQueue] = {}
 
 async def run_temp_package(package_id: str) -> None:
 
-    assert glob.PROJECT
-    project_id = glob.PROJECT.id
+    assert glob.LOCK.project
+    project_id = glob.LOCK.project.id
     glob.TEMPORARY_PACKAGE = True
 
     scene_online = scene_started()
@@ -62,10 +62,12 @@ async def run_temp_package(package_id: str) -> None:
 
     await project.open_project(project_id)
 
-    assert glob.SCENE
-    assert glob.PROJECT
+    assert glob.LOCK.scene
+    assert glob.LOCK.project
 
-    await notif.broadcast_event(sevts.p.OpenProject(sevts.p.OpenProject.Data(glob.SCENE.scene, glob.PROJECT.project)))
+    await notif.broadcast_event(
+        sevts.p.OpenProject(sevts.p.OpenProject.Data(glob.LOCK.scene.scene, glob.LOCK.project.project))
+    )
 
     if scene_online:
         await start_scene()

--- a/src/python/arcor2_arserver/globals.py
+++ b/src/python/arcor2_arserver/globals.py
@@ -4,11 +4,12 @@ from typing import Any, DefaultDict, Dict, List, Optional, Set
 
 from websockets.server import WebSocketServerProtocol as WsClient
 
-from arcor2.cached import UpdateableCachedProject, UpdateableCachedScene
 from arcor2.data import events
 from arcor2.logging import get_aiologger
 from arcor2.object_types.abstract import Generic
+from arcor2_arserver.lock import Lock
 from arcor2_arserver.object_types.data import ObjectTypeDict
+from arcor2_arserver.user import Users
 from arcor2_arserver_data.events.common import ShowMainScreen
 
 logger = get_aiologger("ARServer")
@@ -16,12 +17,7 @@ VERBOSE: bool = False
 
 PORT: int = int(os.getenv("ARCOR2_SERVER_PORT", 6789))
 
-SCENE: Optional[UpdateableCachedScene] = None
-PROJECT: Optional[UpdateableCachedProject] = None
-
 MAIN_SCREEN: Optional[ShowMainScreen.Data] = ShowMainScreen.Data(ShowMainScreen.Data.WhatEnum.ScenesList)
-
-INTERFACES: Set[WsClient] = set()
 
 OBJECT_TYPES: ObjectTypeDict = {}
 
@@ -44,3 +40,7 @@ ROBOT_JOINTS_REGISTERED_UIS: RegisteredUiDict = defaultdict(lambda: set())  # ro
 ROBOT_EEF_REGISTERED_UIS: RegisteredUiDict = defaultdict(lambda: set())  # robot, UIs
 
 OBJECTS_WITH_UPDATED_POSE: Set[str] = set()
+
+LOCK: Lock = Lock()
+
+USERS: Users = Users()

--- a/src/python/arcor2_arserver/helpers.py
+++ b/src/python/arcor2_arserver/helpers.py
@@ -1,6 +1,12 @@
-from typing import Set
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, List, Set, Union
+
+from websockets.server import WebSocketServerProtocol as WsClient
 
 from arcor2.exceptions import Arcor2Exception
+from arcor2_arserver import globals as glob
+from arcor2_arserver.decorators import retry
+from arcor2_arserver.lock.exceptions import CannotLock, LockingException
 
 
 def unique_name(name: str, existing_names: Set[str]) -> None:
@@ -10,3 +16,71 @@ def unique_name(name: str, existing_names: Set[str]) -> None:
 
     if name in existing_names:
         raise Arcor2Exception("Name already exists.")
+
+
+@asynccontextmanager
+async def ctx_write_lock(
+    obj_ids: Union[str, List[str]], owner: str, auto_unlock: bool = True, dry_run: bool = False
+) -> AsyncGenerator[None, None]:
+    @retry(exc=CannotLock, tries=glob.LOCK.LOCK_RETRIES, delay=glob.LOCK.RETRY_WAIT)
+    async def lock():
+        if not await glob.LOCK.write_lock(obj_ids, owner):
+            raise CannotLock("Locking failed")
+
+    await lock()
+    try:
+        yield
+    except Arcor2Exception:
+        if not dry_run and not auto_unlock:
+            await glob.LOCK.write_unlock(obj_ids, owner)
+        raise
+    finally:
+        if dry_run or auto_unlock:
+            await glob.LOCK.write_unlock(obj_ids, owner)
+
+
+@asynccontextmanager
+async def ctx_read_lock(
+    obj_ids: Union[str, List[str]], owner: str, auto_unlock: bool = True, dry_run: bool = False
+) -> AsyncGenerator[None, None]:
+    @retry(exc=CannotLock, tries=glob.LOCK.LOCK_RETRIES, delay=glob.LOCK.RETRY_WAIT)
+    async def lock():
+        if not await glob.LOCK.read_lock(obj_ids, owner):
+            raise CannotLock("Locking failed")
+
+    await lock()
+    try:
+        yield
+    except Arcor2Exception:
+        if not dry_run and not auto_unlock:
+            await glob.LOCK.read_unlock(obj_ids, owner)
+        raise
+    finally:
+        if dry_run or auto_unlock:
+            await glob.LOCK.read_unlock(obj_ids, owner)
+
+
+async def ensure_locked(obj_id: str, ui: WsClient) -> None:
+    """Check if object is write locked.
+
+    Read lock check not needed yet.
+    """
+
+    if not await glob.LOCK.is_write_locked(obj_id, glob.USERS.user_name(ui)):
+        raise LockingException(f"Object is not write locked <{obj_id}>")
+
+
+async def get_unlocked_objects(obj_ids: Union[str, List[str]], owner: str) -> List[str]:
+    """Check if objects are write locked.
+
+    :return: list of objects that are not write locked
+    """
+
+    if isinstance(obj_ids, str):
+        obj_ids = [obj_ids]
+
+    ret: List[str] = []
+    for obj_id in obj_ids:
+        if not await glob.LOCK.is_write_locked(obj_id, owner):
+            ret.append(obj_id)
+    return ret

--- a/src/python/arcor2_arserver/lock/BUILD
+++ b/src/python/arcor2_arserver/lock/BUILD
@@ -1,0 +1,1 @@
+python_library()

--- a/src/python/arcor2_arserver/lock/__init__.py
+++ b/src/python/arcor2_arserver/lock/__init__.py
@@ -1,0 +1,4 @@
+from arcor2_arserver.lock import exceptions, notifications, structures
+from arcor2_arserver.lock.lock import Lock
+
+__all__ = [Lock.__name__, exceptions.__name__, notifications.__name__, structures.__name__]

--- a/src/python/arcor2_arserver/lock/exceptions.py
+++ b/src/python/arcor2_arserver/lock/exceptions.py
@@ -1,0 +1,13 @@
+from arcor2.exceptions import Arcor2Exception
+
+
+class LockingException(Arcor2Exception):
+    pass
+
+
+class CannotUnlock(LockingException):
+    pass
+
+
+class CannotLock(LockingException):
+    pass

--- a/src/python/arcor2_arserver/lock/lock.py
+++ b/src/python/arcor2_arserver/lock/lock.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, Dict, List, Optional, Set, Tuple, Union
+
+from arcor2.cached import CachedProjectException, UpdateableCachedProject, UpdateableCachedScene
+from arcor2.data import common as cmn
+from arcor2.exceptions import Arcor2Exception
+from arcor2_arserver.clients import persistent_storage as storage
+from arcor2_arserver.lock.exceptions import CannotLock, LockingException
+from arcor2_arserver.lock.structures import LockedObject, LockEventData
+
+
+class Lock:
+    class SpecialValues(cmn.StrEnum):
+        SERVER_NAME: str = "SERVER"
+        SCENE_NAME: str = "SCENE"
+        PROJECT_NAME: str = "PROJECT"
+
+        RUNNING_ACTION: str = "ACTION"
+
+    LOCK_TIMEOUT: int = 300  # 5 minutes
+    LOCK_RETRIES: int = 10
+    RETRY_WAIT: float = 0.2
+
+    def __init__(self) -> None:
+        self._scene: Optional[UpdateableCachedScene] = None
+        self._project: Optional[UpdateableCachedProject] = None
+
+        self._lock: asyncio.Lock = asyncio.Lock()
+        self._locked_objects: Dict[str, LockedObject] = {}
+        self._release_tasks: Dict[str, asyncio.Task] = {}
+
+        self.notifications_q: asyncio.Queue[LockEventData] = asyncio.Queue()
+        self._ui_user_locks: Dict[str, Set[str]] = {}
+
+    @property
+    def scene(self) -> Optional[UpdateableCachedScene]:
+        return self._scene
+
+    @scene.setter
+    def scene(self, scene: Optional[UpdateableCachedScene] = None) -> None:
+        self._scene = scene
+
+    @property
+    def project(self) -> Optional[UpdateableCachedProject]:
+        return self._project
+
+    @project.setter
+    def project(self, project: Optional[UpdateableCachedProject] = None) -> None:
+        self._project = project
+
+    @property
+    def all_ui_locks(self) -> Dict[str, Set[str]]:
+        return self._ui_user_locks
+
+    @asynccontextmanager
+    async def get_lock(self, dry_run: bool = False) -> AsyncGenerator[Optional[asyncio.Lock], None]:
+        """Get lock for data structure, method should be used for operation
+        with whole scene/project, no others."""
+
+        yielded = False
+        try:
+            for _ in range(self.LOCK_RETRIES):
+                try:
+                    async with self._lock:
+                        if self._get_write_locks_count():
+                            raise CannotLock("Cannot acquire lock")
+
+                        if not dry_run:
+                            yielded = True
+                            yield self._lock
+                    if dry_run:
+                        yielded = True
+                        yield None
+
+                    break
+                except CannotLock:
+                    await asyncio.sleep(self.RETRY_WAIT)
+        finally:
+            if not yielded:
+                raise CannotLock("Cannot acquire lock")
+
+    async def read_lock(self, obj_ids: Union[List[str], str], owner: str) -> bool:
+
+        if isinstance(obj_ids, str):
+            obj_ids = [obj_ids]
+
+        roots = [await self.get_root_id(obj_id) for obj_id in obj_ids]
+
+        async with self._lock:
+            return self._read_lock(roots, obj_ids, owner)
+
+    def _read_lock(self, roots: List[str], obj_ids: List[str], owner: str) -> bool:
+
+        assert self._lock.locked()
+
+        locked = []
+        for i, obj_id in enumerate(obj_ids):
+            lock_record = self._get_lock_record(roots[i])
+            acquired = lock_record.read_lock(obj_id, owner)
+
+            if acquired:
+                locked.append(obj_id)
+            else:
+                self._read_unlock(roots, locked, owner)
+                return False
+        return True
+
+    async def read_unlock(self, obj_ids: Union[List[str], str], owner: str) -> None:
+
+        if isinstance(obj_ids, str):
+            obj_ids = [obj_ids]
+
+        roots = [await self.get_root_id(obj_id) for obj_id in obj_ids]
+
+        async with self._lock:
+            self._read_unlock(roots, obj_ids, owner)
+
+    def _read_unlock(self, roots: List[str], obj_ids: List[str], owner: str) -> None:
+        """Internal function when lock is acquired."""
+
+        assert self._lock.locked()
+
+        for i, obj_id in enumerate(obj_ids):
+            lock_record = self._get_lock_record(roots[i])
+            try:
+                lock_record.read_unlock(obj_id, owner)
+
+            except LockingException:
+                self._read_unlock(roots[i + 1 :], obj_ids[i + 1 :], owner)
+                raise
+            finally:
+                self._check_and_clean_root(roots[i])
+
+    async def write_lock(
+        self, obj_ids: Union[List[str], str], owner: str, lock_tree: bool = False, notify: bool = False
+    ) -> bool:
+        """Lock object or list of objects for writing, possible to lock whole
+        tree where object(s) is located.
+
+        :param obj_ids: object or objects to be locked
+        :param owner: name of lock owner
+        :param lock_tree: boolean whether lock whole tree
+        :param notify: if set, broadcast information about locked objects and store those objects in user lock database
+        :return: boolean whether lock was successful
+        """
+        # TODO does it make sense to lock list of trees? currently in project only
+
+        if isinstance(obj_ids, str):
+            obj_ids = [obj_ids]
+
+        roots = [await self.get_root_id(obj_id) for obj_id in obj_ids]
+
+        async with self._lock:
+            ret = self._write_lock(roots, obj_ids, owner, lock_tree)
+
+        if ret and notify:
+            ui_locked = obj_ids
+            if lock_tree:
+                for obj_id in roots:  # TODO lock only tree from affected object
+                    ui_locked.extend(self.get_all_children(obj_id))
+                ui_locked += roots
+            self._upsert_user_locked_objects(owner, ui_locked)
+            self.notifications_q.put_nowait(LockEventData(ui_locked, owner, True))
+        return ret
+
+    def _write_lock(self, roots: List[str], obj_ids: List[str], owner: str, lock_tree: bool = False) -> bool:
+
+        assert self._lock.locked()
+
+        locked = []
+        for i, obj_id in enumerate(obj_ids):
+            lock_record = self._get_lock_record(roots[i])
+            acquired = lock_record.write_lock(obj_id, owner, lock_tree)
+
+            if acquired:
+                locked.append(obj_id)
+            else:
+                self._write_unlock(roots, locked, owner)
+                return False
+        return True
+
+    async def write_unlock(self, obj_ids: Union[List[str], str], owner: str, notify: bool = False) -> None:
+
+        if isinstance(obj_ids, str):
+            obj_ids = [obj_ids]
+
+        roots = [await self.get_root_id(obj_id) for obj_id in obj_ids]
+
+        async with self._lock:
+            locked_trees = self._write_unlock(roots, obj_ids, owner)
+
+        ui_locked = obj_ids
+        for obj_id, locked_tree in zip(roots, locked_trees):  # TODO lock only tree from affected object
+            if locked_tree:
+                ui_locked.extend(self.get_all_children(obj_id))
+                ui_locked.extend(roots)
+
+        # Always try to remove locked objects from database, so it won't get messy when deleting too many objects
+        self._remove_user_locked_objects(owner, ui_locked)
+
+        if notify:
+            self.notifications_q.put_nowait(LockEventData(ui_locked, owner))
+
+    def _write_unlock(self, roots: List[str], obj_ids: List[str], owner: str) -> List[bool]:
+        """Internal function when lock is acquired."""
+
+        assert self._lock.locked()
+
+        ret: List[bool] = []
+        for i, obj_id in enumerate(obj_ids):
+            lock_record = self._get_lock_record(roots[i])
+            ret.append(lock_record.tree)
+            try:
+                lock_record.write_unlock(obj_id, owner)
+
+            except LockingException:
+                self._write_unlock(roots[i + 1 :], obj_ids[i + 1 :], owner)
+                raise
+            finally:
+                self._check_and_clean_root(roots[i])
+        return ret
+
+    async def is_write_locked(self, obj_id: str, owner: str) -> bool:
+
+        root_id = await self.get_root_id(obj_id)
+
+        async with self._lock:
+            lock_record = self._locked_objects.get(root_id)
+            if not lock_record:
+                return False
+
+            if obj_id in lock_record.write and owner in lock_record.write[obj_id].owners:
+                return True
+
+            if lock_record.tree and set(lock_record.write).intersection(self.get_all_parents(obj_id)):
+                return True
+            return False
+
+    async def is_read_locked(self, obj_id: str, owner: str) -> bool:
+
+        root_id = await self.get_root_id(obj_id)
+
+        async with self._lock:
+            return self._is_read_locked(root_id, obj_id, owner)
+
+    def _is_read_locked(self, root_id: str, obj_id: str, owner: str) -> bool:
+
+        assert self._lock.locked()
+
+        lock_record = self._locked_objects.get(root_id)
+        if not lock_record:
+            return False
+
+        return obj_id in lock_record.read and owner in lock_record.read[obj_id].owners
+
+    async def get_locked_roots_count(self) -> int:
+
+        async with self._lock:
+            return len(self._locked_objects)
+
+    async def get_write_locks_count(self) -> int:
+
+        async with self._lock:
+            return self._get_write_locks_count()
+
+    def _get_write_locks_count(self) -> int:
+
+        assert self._lock.locked()
+
+        return sum(len(lock.write) for lock in self._locked_objects.values())
+
+    async def get_root_id(self, obj_id: str) -> str:
+        """Retrieve root object id for given object."""
+
+        if obj_id in (
+            self.SpecialValues.SCENE_NAME,
+            self.SpecialValues.PROJECT_NAME,
+            self.SpecialValues.RUNNING_ACTION,
+        ):
+            return obj_id
+
+        elif self.project and self.scene:
+            if obj_id in (self.scene.id, self.project.id, cmn.LogicItem.START, cmn.LogicItem.END):
+                return obj_id
+            elif obj_id in self.scene.object_ids:
+                # TODO implement with scene object hierarchy
+                return obj_id
+            else:
+                parent = self.project.get_parent_id(obj_id)
+                ret = parent if parent else obj_id
+                try:
+                    while parent:
+                        parent = self.project.get_parent_id(parent)
+                        if parent and parent != ret:
+                            ret = parent
+                except CachedProjectException:
+                    ...
+                return ret
+
+        elif self.scene and obj_id in self.scene.object_ids | {self.scene.id}:
+            # TODO implement with scene object hierarchy
+            return obj_id
+
+        # locking on dashboard, check if scene or project exists
+        if next((True for scene in (await storage.get_scenes()).items if scene.id == obj_id), False):
+            return obj_id
+        elif next((True for project in (await storage.get_projects()).items if project.id == obj_id), False):
+            return obj_id
+
+        raise Arcor2Exception(f"Unknown object '{obj_id}'")
+
+    def _get_lock_record(self, root_id: str) -> LockedObject:
+        """Create and/or retrieve lock record for root_id."""
+
+        assert self._lock.locked()
+
+        if root_id not in self._locked_objects:
+            self._locked_objects[root_id] = LockedObject()
+
+        return self._locked_objects[root_id]
+
+    async def update_write_lock(self, locked_obj_id: str, parent_id: str, owner: str):
+        """Update lock record of locked object to new root, both objects
+        expected to be locked.
+
+        :param locked_obj_id: ID of locked object to be updated
+        :param parent_id: ID of previous parent of locked object
+        :param owner: name of lock owner
+        """
+
+        new_root_id = await self.get_root_id(locked_obj_id)
+
+        async with self._lock:
+            self._write_unlock([parent_id], [locked_obj_id], owner)
+            self._write_lock([new_root_id], [locked_obj_id], owner)
+
+    def _check_and_clean_root(self, root: str) -> None:
+
+        assert self._lock.locked()
+
+        if self._locked_objects[root].is_empty():
+            del self._locked_objects[root]
+
+    async def schedule_auto_release(self, owner: str) -> None:
+
+        self._release_tasks[owner] = asyncio.create_task(self._release_all_owner_locks(owner))
+
+    async def cancel_auto_release(self, owner: str) -> None:
+
+        if owner in self._release_tasks:
+            self._release_tasks[owner].cancel()
+            del self._release_tasks[owner]
+
+    async def _release_all_owner_locks(self, owner: str) -> None:
+
+        await asyncio.sleep(self.LOCK_TIMEOUT)
+
+        unlocked: Set[str] = set()
+        async with self._lock:
+            read, write = self._get_owner_locks(owner)
+
+            self._read_unlock(list(read), list(read.values()), owner)
+            unlocked.update(read.values())
+            self._write_unlock(list(write), list(write.values()), owner)
+            unlocked.update(write.values())
+
+        if unlocked:
+            self.notifications_q.put_nowait(LockEventData(list(unlocked), owner))
+
+    async def get_owner_locks(self, owner: str) -> Tuple[Dict[str, str], Dict[str, str]]:
+        """Finds which locks belongs to owner
+        :return: object_id: root id
+        """
+
+        async with self._lock:
+            return self._get_owner_locks(owner)
+
+    def _get_owner_locks(self, owner: str) -> Tuple[Dict[str, str], Dict[str, str]]:
+        """Finds which locks belongs to owner
+        :return: tuple of dict(object_id: root_id), first one represents read locks, second one write locks
+        """
+
+        assert self._lock.locked()
+
+        read: Dict[str, str] = {}
+        write: Dict[str, str] = {}
+
+        for root, data in self._locked_objects.items():
+            for obj_id, obj_data in data.read.items():
+                if owner in obj_data.owners:
+                    read[obj_id] = root
+            for obj_id, obj_data in data.write.items():
+                if owner in obj_data.owners:
+                    write[obj_id] = root
+
+        return read, write
+
+    def _upsert_user_locked_objects(self, owner: str, obj_ids: List[str]) -> None:
+        """Add objects where lock is visible in UI.
+
+        :param owner: user name of locks owner
+        :param obj_ids: objects to be added to user lock database
+        """
+
+        if owner not in self._ui_user_locks:
+            self._ui_user_locks[owner] = set()
+
+        self._ui_user_locks[owner].update(obj_ids)
+
+    def _remove_user_locked_objects(self, owner: str, obj_ids: List[str]) -> None:
+        """Remove items where lock is visible in UI.
+
+        :param owner: user name of locks owner
+        :param obj_ids: objects to be removed from user lock database
+        """
+
+        if owner in self._ui_user_locks:
+            self._ui_user_locks[owner].difference_update(obj_ids)
+
+            if not self._ui_user_locks[owner]:
+                del self._ui_user_locks[owner]
+
+    def get_all_children(self, obj_id: str) -> Set[str]:
+
+        ret: List[str] = []
+        if self.project:
+            childs = self.project.childs(obj_id)
+            ret.extend(childs)
+            for child in childs:
+                ret.extend(self.get_all_children(child))
+
+        return set(ret)
+
+    def get_all_parents(self, obj_id: str) -> Set[str]:
+
+        parents: Set[str] = set()
+        if self.project:
+            parent = self.project.get_parent_id(obj_id)
+            while parent:
+                parents.add(parent)
+                parent = self.project.get_parent_id(parent)
+        elif self.scene:
+            ...  # TODO implement with scene object hierarchy
+
+        return parents
+
+    async def check_remove(self, obj_id: str, owner: str) -> bool:
+        """Check if object can be removed, e.g. no child locked, not in locked
+        tree."""
+
+        def check_owner(_root: str, obj_ids: Set[str], read: bool = False) -> bool:
+            lock_item = self._locked_objects[_root]
+            for _obj_id in obj_ids:
+                if read:
+                    if owner not in lock_item.read[_obj_id].owners:
+                        return False
+                    if lock_item.read[_obj_id].count != 1:
+                        return False
+                else:
+                    if owner not in lock_item.write[_obj_id].owners:
+                        return False
+            return True
+
+        root = await self.get_root_id(obj_id)
+        children = self.get_all_children(obj_id)
+
+        async with self._lock:
+            if root in self._locked_objects:
+                if not check_owner(root, children.intersection(self._locked_objects[root].write)):
+                    return False
+                if not check_owner(root, children.intersection(self._locked_objects[root].read), True):
+                    return False
+            return True
+
+    def get_by_id(
+        self, obj_id: str
+    ) -> Union[cmn.SceneObject, cmn.BareActionPoint, cmn.NamedOrientation, cmn.ProjectRobotJoints, cmn.Action]:
+
+        if self.project:
+            try:
+                return self.project.get_by_id(obj_id)
+            except CachedProjectException:
+                ...
+
+        if self.scene:  # TODO update with scene object hierarchy
+            if obj_id in self.scene.object_ids:
+                return self.scene.object(obj_id)
+
+        raise Arcor2Exception(f"Object ID {obj_id} not found.")

--- a/src/python/arcor2_arserver/lock/notifications.py
+++ b/src/python/arcor2_arserver/lock/notifications.py
@@ -1,0 +1,17 @@
+from arcor2_arserver import globals as glob
+from arcor2_arserver import notifications as notif
+from arcor2_arserver_data import events as sevts
+
+
+async def run_lock_notification_worker():
+    while True:
+        notif_data = await glob.LOCK.notifications_q.get()
+        obj_ids = notif_data.obj_ids
+        data = sevts.lk.LockData(obj_ids if isinstance(obj_ids, list) else [obj_ids], notif_data.owner)
+
+        evt = sevts.lk.ObjectsLocked(data) if notif_data.lock else sevts.lk.ObjectsUnlocked(data)
+
+        if notif_data.client:
+            await notif.event(notif_data.client, evt)
+        else:
+            await notif.broadcast_event(evt)

--- a/src/python/arcor2_arserver/lock/structures.py
+++ b/src/python/arcor2_arserver/lock/structures.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+from websockets.server import WebSocketServerProtocol as WsClient
+
+from arcor2_arserver.lock.exceptions import CannotUnlock
+
+
+class LockEventData:
+    __slots__ = "obj_ids", "owner", "lock", "client"
+
+    def __init__(
+        self, obj_ids: Union[List[str], str], owner: str, lock: bool = False, client: Optional[WsClient] = None
+    ):
+        self.obj_ids = obj_ids
+        self.owner = owner
+        self.lock = lock
+        self.client = client
+
+
+class Data:
+    __slots__ = "owners", "count"
+
+    def __init__(self, owner: str) -> None:
+        self.owners: List[str] = [owner]
+        self.count: int = 1
+
+    def inc_count(self) -> None:
+        self.count += 1
+
+    def dec_count(self) -> None:
+        self.count -= 1
+
+
+class LockedObject:
+    __slots__ = "read", "write", "tree"
+
+    def __init__(self) -> None:
+
+        # object id: data
+        self.read: Dict[str, Data] = {}
+        self.write: Dict[str, Data] = {}
+
+        self.tree: bool = False
+
+    def read_lock(self, obj_id: str, owner: str) -> bool:
+
+        if self.tree:
+            return False
+
+        if obj_id in self.write:
+            return False
+
+        already_locked = obj_id in self.read
+        if already_locked:
+            self.read[obj_id].owners.append(owner)
+            self.read[obj_id].inc_count()
+        else:
+            self.read[obj_id] = Data(owner)
+        return True
+
+    def read_unlock(self, obj_id: str, owner: str) -> None:
+
+        if obj_id not in self.read:
+            raise CannotUnlock(f"Object is not read locked by '{owner}'")
+
+        if owner not in self.read[obj_id].owners:
+            raise CannotUnlock(f"Object lock is not owned by '{owner}'")
+
+        if self.read[obj_id].count > 1:
+            lock_data = self.read[obj_id]
+            try:
+                lock_data.owners.remove(owner)
+            except ValueError:
+                raise CannotUnlock(f"'{owner}' does not own read lock for object '{obj_id}'")
+
+            lock_data.dec_count()
+        else:
+            del self.read[obj_id]
+
+    def write_lock(self, obj_id: str, owner: str, lock_tree: bool) -> bool:
+
+        # TODO maybe exception would be better?
+        if self.tree or obj_id in self.write or obj_id in self.read:
+            return False
+
+        if lock_tree and (self.read or self.write):
+            return False
+
+        self.write[obj_id] = Data(owner)
+        self.tree = lock_tree
+        return True
+
+    def write_unlock(self, obj_id: str, owner: str) -> None:
+
+        if obj_id not in self.write:
+            raise CannotUnlock(f"Object is not write locked by '{owner}'")
+
+        if owner not in self.write[obj_id].owners:
+            raise CannotUnlock(f"Object lock is not owned by '{owner}'")
+
+        if self.tree:
+            self.tree = False
+        del self.write[obj_id]
+
+    def is_empty(self) -> bool:
+
+        return not self.read and not self.write

--- a/src/python/arcor2_arserver/notifications.py
+++ b/src/python/arcor2_arserver/notifications.py
@@ -10,10 +10,10 @@ from arcor2_arserver import globals as glob
 
 async def broadcast_event(event: events.Event, exclude_ui: Optional[WebSocketServerProtocol] = None) -> None:
 
-    if (exclude_ui is None and glob.INTERFACES) or (exclude_ui and len(glob.INTERFACES) > 1):
+    if (exclude_ui is None and glob.USERS.interfaces) or (exclude_ui and len(glob.USERS.interfaces) > 1):
         message = event.to_json()
         await asyncio.gather(
-            *[ws_server.send_json_to_client(intf, message) for intf in glob.INTERFACES if intf != exclude_ui]
+            *[ws_server.send_json_to_client(intf, message) for intf in glob.USERS.interfaces if intf != exclude_ui]
         )
 
 

--- a/src/python/arcor2_arserver/objects_actions.py
+++ b/src/python/arcor2_arserver/objects_actions.py
@@ -38,10 +38,10 @@ def get_types_dict() -> TypesDict:
 
 def get_obj_type_name(object_id: str) -> str:
 
-    assert glob.SCENE
+    assert glob.LOCK.scene
 
     try:
-        return glob.SCENE.object(object_id).type
+        return glob.LOCK.scene.object(object_id).type
     except KeyError:
         raise Arcor2Exception("Unknown object id.")
 
@@ -152,7 +152,7 @@ async def get_object_types() -> None:
     :return:
     """
 
-    assert glob.SCENE is None
+    assert glob.LOCK.scene is None
 
     initialization = False
 

--- a/src/python/arcor2_arserver/rpc/__init__.py
+++ b/src/python/arcor2_arserver/rpc/__init__.py
@@ -1,3 +1,12 @@
-from arcor2_arserver.rpc import camera, execution, objects, project, robot, scene
+from arcor2_arserver.rpc import camera, execution, lock, objects, project, robot, scene, user
 
-__all__ = [execution.__name__, objects.__name__, project.__name__, robot.__name__, scene.__name__, camera.__name__]
+__all__ = [
+    execution.__name__,
+    objects.__name__,
+    project.__name__,
+    robot.__name__,
+    scene.__name__,
+    camera.__name__,
+    lock.__name__,
+    user.__name__,
+]

--- a/src/python/arcor2_arserver/rpc/camera.py
+++ b/src/python/arcor2_arserver/rpc/camera.py
@@ -11,6 +11,7 @@ from arcor2_arserver import globals as glob
 from arcor2_arserver import notifications as notif
 from arcor2_arserver.camera import get_camera_instance
 from arcor2_arserver.decorators import scene_needed
+from arcor2_arserver.helpers import ensure_locked
 from arcor2_arserver.scene import ensure_scene_started, update_scene_object_pose
 from arcor2_arserver_data.events.common import ProcessState
 from arcor2_arserver_data.rpc.camera import CalibrateCamera, CameraColorImage, CameraColorParameters
@@ -19,7 +20,9 @@ from arcor2_arserver_data.rpc.camera import CalibrateCamera, CameraColorImage, C
 @scene_needed
 async def camera_color_image_cb(req: CameraColorImage.Request, ui: WsClient) -> CameraColorImage.Response:
 
-    assert glob.SCENE
+    assert glob.LOCK.scene
+
+    await ensure_locked(req.args.id, ui)
 
     ensure_scene_started()
     camera = get_camera_instance(req.args.id)
@@ -33,7 +36,9 @@ async def camera_color_parameters_cb(
     req: CameraColorParameters.Request, ui: WsClient
 ) -> CameraColorParameters.Response:
 
-    assert glob.SCENE
+    assert glob.LOCK.scene
+
+    await ensure_locked(req.args.id, ui)
 
     ensure_scene_started()
     camera = get_camera_instance(req.args.id)
@@ -48,7 +53,7 @@ CAMERA_CALIB = "CameraCalibration"
 async def calibrate_camera(camera: Camera) -> None:
 
     assert camera.color_camera_params
-    assert glob.SCENE
+    assert glob.LOCK.scene
 
     await notif.broadcast_event(ProcessState(ProcessState.Data(CAMERA_CALIB, ProcessState.Data.StateEnum.Started)))
     try:
@@ -61,14 +66,14 @@ async def calibrate_camera(camera: Camera) -> None:
         glob.logger.exception("Failed to calibrate the camera.")
         return
 
-    await update_scene_object_pose(glob.SCENE.object(camera.id), estimated_pose.pose, camera)
+    await update_scene_object_pose(glob.LOCK.scene.object(camera.id), estimated_pose.pose, camera)
     await notif.broadcast_event(ProcessState(ProcessState.Data(CAMERA_CALIB, ProcessState.Data.StateEnum.Finished)))
 
 
 @scene_needed
 async def calibrate_camera_cb(req: CalibrateCamera.Request, ui: WsClient) -> None:
 
-    assert glob.SCENE
+    assert glob.LOCK.scene
 
     ensure_scene_started()
     camera = get_camera_instance(req.args.id)
@@ -76,5 +81,7 @@ async def calibrate_camera_cb(req: CalibrateCamera.Request, ui: WsClient) -> Non
     # TODO check camera features / meta if it supports getting color image
     if not camera.color_camera_params:
         raise Arcor2Exception("Camera parameters not available.")
+
+    await ensure_locked(req.args.id, ui)
 
     asyncio.ensure_future(calibrate_camera(camera))

--- a/src/python/arcor2_arserver/rpc/lock.py
+++ b/src/python/arcor2_arserver/rpc/lock.py
@@ -1,0 +1,29 @@
+from websockets.server import WebSocketServerProtocol as WsClient
+
+from arcor2_arserver import globals as glob
+from arcor2_arserver.lock.exceptions import CannotLock
+from arcor2_arserver_data import rpc as srpc
+
+
+async def write_lock_cb(req: srpc.lock.WriteLock.Request, ui: WsClient) -> None:
+
+    if not await glob.LOCK.write_lock(req.args.object_id, glob.USERS.user_name(ui), req.args.lock_tree, notify=True):
+        raise CannotLock("Cannot lock")
+
+
+async def write_unlock_cb(req: srpc.lock.WriteUnlock.Request, ui: WsClient) -> None:
+
+    await glob.LOCK.write_unlock(req.args.object_id, glob.USERS.user_name(ui), notify=True)
+
+
+async def read_lock_cb(req: srpc.lock.ReadLock.Request, ui: WsClient) -> None:
+
+    # TODO currently unused, maybe delete?
+    if not await glob.LOCK.read_lock(req.args.object_id, glob.USERS.user_name(ui)):
+        raise CannotLock("Cannot lock")
+
+
+async def read_unlock_cb(req: srpc.lock.ReadUnlock.Request, ui: WsClient) -> None:
+
+    # TODO currently unused, maybe delete?
+    await glob.LOCK.read_unlock(req.args.object_id, glob.USERS.user_name(ui))

--- a/src/python/arcor2_arserver/rpc/objects.py
+++ b/src/python/arcor2_arserver/rpc/objects.py
@@ -19,6 +19,7 @@ from arcor2_arserver import objects_actions as osa
 from arcor2_arserver import settings
 from arcor2_arserver.clients import persistent_storage as storage
 from arcor2_arserver.decorators import no_project, project_needed, scene_needed
+from arcor2_arserver.helpers import ctx_read_lock, ensure_locked
 from arcor2_arserver.object_types.data import ObjectTypeData
 from arcor2_arserver.object_types.source import new_object_type
 from arcor2_arserver.object_types.utils import add_ancestor_actions, object_actions, remove_object_type
@@ -48,75 +49,80 @@ def clean_up_after_focus(obj_id: str) -> None:
 @no_project
 async def focus_object_start_cb(req: srpc.o.FocusObjectStart.Request, ui: WsClient) -> None:
 
-    ensure_scene_started()
+    # TODO this event should take long time, notify UI that robot is locked
+    async with ctx_read_lock(
+        [req.args.object_id, req.args.robot.robot_id], glob.USERS.user_name(ui), auto_unlock=False
+    ):
+        ensure_scene_started()
 
-    obj_id = req.args.object_id
+        obj_id = req.args.object_id
 
-    if obj_id in FOCUS_OBJECT_ROBOT:
-        raise Arcor2Exception("Focusing already started.")
+        if obj_id in FOCUS_OBJECT_ROBOT:
+            raise Arcor2Exception("Focusing already started.")
 
-    if obj_id not in glob.SCENE_OBJECT_INSTANCES:
-        raise Arcor2Exception("Unknown object.")
+        if obj_id not in glob.SCENE_OBJECT_INSTANCES:
+            raise Arcor2Exception("Unknown object.")
 
-    inst = await osa.get_robot_instance(req.args.robot.robot_id, req.args.robot.end_effector)
+        inst = await osa.get_robot_instance(req.args.robot.robot_id, req.args.robot.end_effector)
 
-    robot_type = glob.OBJECT_TYPES[inst.__class__.__name__]
-    assert robot_type.robot_meta
+        robot_type = glob.OBJECT_TYPES[inst.__class__.__name__]
+        assert robot_type.robot_meta
 
-    obj_type = glob.OBJECT_TYPES[osa.get_obj_type_name(obj_id)].meta
+        obj_type = glob.OBJECT_TYPES[osa.get_obj_type_name(obj_id)].meta
 
-    if not obj_type.has_pose:
-        raise Arcor2Exception("Only available for objects with pose.")
+        if not obj_type.has_pose:
+            raise Arcor2Exception("Only available for objects with pose.")
 
-    if not obj_type.object_model or obj_type.object_model.type != Model3dType.MESH:
-        raise Arcor2Exception("Only available for objects with mesh model.")
+        if not obj_type.object_model or obj_type.object_model.type != Model3dType.MESH:
+            raise Arcor2Exception("Only available for objects with mesh model.")
 
-    assert obj_type.object_model.mesh
+        assert obj_type.object_model.mesh
 
-    focus_points = obj_type.object_model.mesh.focus_points
+        focus_points = obj_type.object_model.mesh.focus_points
 
-    if not focus_points:
-        raise Arcor2Exception("focusPoints not defined for the mesh.")
+        if not focus_points:
+            raise Arcor2Exception("focusPoints not defined for the mesh.")
 
-    FOCUS_OBJECT_ROBOT[req.args.object_id] = req.args.robot
-    FOCUS_OBJECT[obj_id] = {}
-    glob.logger.info(f"Start of focusing for {obj_id}.")
-    return None
+        FOCUS_OBJECT_ROBOT[req.args.object_id] = req.args.robot
+        FOCUS_OBJECT[obj_id] = {}
+        glob.logger.info(f"Start of focusing for {obj_id}.")
+        return None
 
 
 @no_project
 async def focus_object_cb(req: srpc.o.FocusObject.Request, ui: WsClient) -> srpc.o.FocusObject.Response:
 
-    obj_id = req.args.object_id
-    pt_idx = req.args.point_idx
+    async with ctx_read_lock(req.args.object_id, glob.USERS.user_name(ui), auto_unlock=False):
+        obj_id = req.args.object_id
+        pt_idx = req.args.point_idx
 
-    if obj_id not in glob.SCENE_OBJECT_INSTANCES:
-        raise Arcor2Exception("Unknown object_id.")
+        if obj_id not in glob.SCENE_OBJECT_INSTANCES:
+            raise Arcor2Exception("Unknown object_id.")
 
-    obj_type = glob.OBJECT_TYPES[osa.get_obj_type_name(obj_id)].meta
+        obj_type = glob.OBJECT_TYPES[osa.get_obj_type_name(obj_id)].meta
 
-    assert obj_type.has_pose
-    assert obj_type.object_model
-    assert obj_type.object_model.mesh
+        assert obj_type.has_pose
+        assert obj_type.object_model
+        assert obj_type.object_model.mesh
 
-    focus_points = obj_type.object_model.mesh.focus_points
+        focus_points = obj_type.object_model.mesh.focus_points
 
-    assert focus_points
+        assert focus_points
 
-    if pt_idx < 0 or pt_idx > len(focus_points) - 1:
-        raise Arcor2Exception("Index out of range.")
+        if pt_idx < 0 or pt_idx > len(focus_points) - 1:
+            raise Arcor2Exception("Index out of range.")
 
-    if obj_id not in FOCUS_OBJECT:
-        glob.logger.info(f"Start of focusing for {obj_id}.")
-        FOCUS_OBJECT[obj_id] = {}
+        if obj_id not in FOCUS_OBJECT:
+            glob.logger.info(f"Start of focusing for {obj_id}.")
+            FOCUS_OBJECT[obj_id] = {}
 
-    robot_id, end_effector = FOCUS_OBJECT_ROBOT[obj_id].as_tuple()
+        robot_id, end_effector = FOCUS_OBJECT_ROBOT[obj_id].as_tuple()
 
-    FOCUS_OBJECT[obj_id][pt_idx] = await get_end_effector_pose(robot_id, end_effector)
+        FOCUS_OBJECT[obj_id][pt_idx] = await get_end_effector_pose(robot_id, end_effector)
 
-    r = srpc.o.FocusObject.Response()
-    r.data = r.Data(finished_indexes=list(FOCUS_OBJECT[obj_id].keys()))
-    return r
+        r = srpc.o.FocusObject.Response()
+        r.data = r.Data(finished_indexes=list(FOCUS_OBJECT[obj_id].keys()))
+        return r
 
 
 @scene_needed
@@ -127,6 +133,8 @@ async def focus_object_done_cb(req: srpc.o.FocusObjectDone.Request, ui: WsClient
 
     if obj_id not in FOCUS_OBJECT:
         raise Arcor2Exception("focusObjectStart/focusObject has to be called first.")
+
+    await ensure_locked(req.args.id, ui)
 
     obj_type = glob.OBJECT_TYPES[osa.get_obj_type_name(obj_id)].meta
 
@@ -140,9 +148,9 @@ async def focus_object_done_cb(req: srpc.o.FocusObjectDone.Request, ui: WsClient
     if len(FOCUS_OBJECT[obj_id]) < len(focus_points):
         raise Arcor2Exception("Not all points were done.")
 
-    assert glob.SCENE
+    assert glob.LOCK.scene
 
-    obj = glob.SCENE.object(obj_id)
+    obj = glob.LOCK.scene.object(obj_id)
     assert obj.pose
 
     obj_inst = glob.SCENE_OBJECT_INSTANCES[obj_id]
@@ -165,90 +173,98 @@ async def focus_object_done_cb(req: srpc.o.FocusObjectDone.Request, ui: WsClient
     except scene_srv.SceneServiceException as e:
         glob.logger.error(f"Focus failed with: {e}, mfa: {mfa}.")
         raise Arcor2Exception("Focusing failed.") from e
+    finally:
+        to_unlock: List[str] = []
+        try:
+            to_unlock.append(FOCUS_OBJECT_ROBOT[obj_id].robot_id)
+        except KeyError:
+            ...
+        await glob.LOCK.read_unlock(to_unlock, glob.USERS.user_name(ui))
 
     glob.logger.info(f"Done focusing for {obj_id}.")
 
     clean_up_after_focus(obj_id)
 
-    asyncio.ensure_future(update_scene_object_pose(obj, new_pose, obj_inst))
+    asyncio.ensure_future(update_scene_object_pose(obj, new_pose, obj_inst, glob.USERS.user_name(ui)))
 
     return None
 
 
 async def new_object_type_cb(req: srpc.o.NewObjectType.Request, ui: WsClient) -> None:
 
-    meta = req.args
+    async with glob.LOCK.get_lock(req.dry_run):
+        meta = req.args
 
-    if meta.type in glob.OBJECT_TYPES:
-        raise Arcor2Exception("Object type already exists.")
+        if meta.type in glob.OBJECT_TYPES:
+            raise Arcor2Exception("Object type already exists.")
 
-    hlp.is_valid_type(meta.type)
+        hlp.is_valid_type(meta.type)
 
-    if meta.base not in glob.OBJECT_TYPES:
-        raise Arcor2Exception(
-            f"Unknown base object type '{meta.base}', " f"known types are: {', '.join(glob.OBJECT_TYPES.keys())}."
+        if meta.base not in glob.OBJECT_TYPES:
+            raise Arcor2Exception(
+                f"Unknown base object type '{meta.base}', " f"known types are: {', '.join(glob.OBJECT_TYPES.keys())}."
+            )
+
+        base = glob.OBJECT_TYPES[meta.base]
+
+        if base.meta.disabled:
+            raise Arcor2Exception("Base object is disabled.")
+
+        assert base.type_def is not None
+
+        if issubclass(base.type_def, Robot):
+            raise Arcor2Exception("Can't subclass Robot.")
+
+        meta.has_pose = issubclass(base.type_def, GenericWithPose)
+
+        if not meta.has_pose and meta.object_model:
+            raise Arcor2Exception("Object without pose can't have collision model.")
+
+        if req.dry_run:
+            return None
+
+        obj = meta.to_object_type()
+        ast = new_object_type(glob.OBJECT_TYPES[meta.base].meta, meta)
+        obj.source = tree_to_str(ast)
+
+        if meta.object_model:
+
+            if meta.object_model.type == Model3dType.MESH:
+
+                # TODO check whether mesh id exists - if so, then use existing mesh, if not, upload a new one
+                # ...get whole mesh (focus_points) based on mesh id
+                assert meta.object_model.mesh
+                try:
+                    meta.object_model.mesh = await storage.get_mesh(meta.object_model.mesh.id)
+                except storage.ProjectServiceException as e:
+                    glob.logger.error(e)
+                    raise Arcor2Exception(f"Mesh ID {meta.object_model.mesh.id} does not exist.")
+
+            else:
+
+                meta.object_model.model().id = meta.type
+                await storage.put_model(meta.object_model.model())
+
+        type_def = await hlp.run_in_executor(
+            hlp.save_and_import_type_def,
+            obj.source,
+            obj.id,
+            base.type_def,
+            settings.OBJECT_TYPE_PATH,
+            settings.OBJECT_TYPE_MODULE,
         )
+        assert issubclass(type_def, base.type_def)
+        actions = object_actions(type_def, ast)
 
-    base = glob.OBJECT_TYPES[meta.base]
+        await storage.update_object_type(obj)
 
-    if base.meta.disabled:
-        raise Arcor2Exception("Base object is disabled.")
+        glob.OBJECT_TYPES[meta.type] = ObjectTypeData(meta, type_def, actions, ast)
+        add_ancestor_actions(meta.type, glob.OBJECT_TYPES)
 
-    assert base.type_def is not None
-
-    if issubclass(base.type_def, Robot):
-        raise Arcor2Exception("Can't subclass Robot.")
-
-    meta.has_pose = issubclass(base.type_def, GenericWithPose)
-
-    if not meta.has_pose and meta.object_model:
-        raise Arcor2Exception("Object without pose can't have collision model.")
-
-    if req.dry_run:
+        evt = sevts.o.ChangedObjectTypes([meta])
+        evt.change_type = events.Event.Type.ADD
+        asyncio.ensure_future(notif.broadcast_event(evt))
         return None
-
-    obj = meta.to_object_type()
-    ast = new_object_type(glob.OBJECT_TYPES[meta.base].meta, meta)
-    obj.source = tree_to_str(ast)
-
-    if meta.object_model:
-
-        if meta.object_model.type == Model3dType.MESH:
-
-            # TODO check whether mesh id exists - if so, then use existing mesh, if not, upload a new one
-            # ...get whole mesh (focus_points) based on mesh id
-            assert meta.object_model.mesh
-            try:
-                meta.object_model.mesh = await storage.get_mesh(meta.object_model.mesh.id)
-            except storage.ProjectServiceException as e:
-                glob.logger.error(e)
-                raise Arcor2Exception(f"Mesh ID {meta.object_model.mesh.id} does not exist.")
-
-        else:
-
-            meta.object_model.model().id = meta.type
-            await storage.put_model(meta.object_model.model())
-
-    type_def = await hlp.run_in_executor(
-        hlp.save_and_import_type_def,
-        obj.source,
-        obj.id,
-        base.type_def,
-        settings.OBJECT_TYPE_PATH,
-        settings.OBJECT_TYPE_MODULE,
-    )
-    assert issubclass(type_def, base.type_def)
-    actions = object_actions(type_def, ast)
-
-    await storage.update_object_type(obj)
-
-    glob.OBJECT_TYPES[meta.type] = ObjectTypeData(meta, type_def, actions, ast)
-    add_ancestor_actions(meta.type, glob.OBJECT_TYPES)
-
-    evt = sevts.o.ChangedObjectTypes([meta])
-    evt.change_type = events.Event.Type.ADD
-    asyncio.ensure_future(notif.broadcast_event(evt))
-    return None
 
 
 async def get_object_actions_cb(req: srpc.o.GetActions.Request, ui: WsClient) -> srpc.o.GetActions.Response:
@@ -271,50 +287,51 @@ def check_scene_for_object_type(scene: CachedScene, object_type: str) -> None:
 
 async def delete_object_type_cb(req: srpc.o.DeleteObjectType.Request, ui: WsClient) -> None:
 
-    try:
-        obj_type = glob.OBJECT_TYPES[req.args.id]
-    except KeyError:
-        raise Arcor2Exception("Unknown object type.")
-
-    if obj_type.meta.built_in:
-        raise Arcor2Exception("Can't delete built-in type.")
-
-    for obj in glob.OBJECT_TYPES.values():
-        if obj.meta.base == req.args.id:
-            raise Arcor2Exception(f"Object type is base of '{obj.meta.type}'.")
-
-    async for scene in scenes():
-        check_scene_for_object_type(scene, req.args.id)
-
-    if glob.SCENE:
-        check_scene_for_object_type(glob.SCENE, req.args.id)
-
-    if req.dry_run:
-        return
-
-    await storage.delete_object_type(req.args.id)
-
-    # do not care so much if delete_model fails
-    if obj_type.meta.object_model:
+    async with glob.LOCK.get_lock(req.dry_run):
         try:
-            await storage.delete_model(obj_type.meta.object_model.model().id)
-        except storage.ProjectServiceException as e:
-            glob.logger.error(str(e))
+            obj_type = glob.OBJECT_TYPES[req.args.id]
+        except KeyError:
+            raise Arcor2Exception("Unknown object type.")
 
-    del glob.OBJECT_TYPES[req.args.id]
-    remove_object_type(req.args.id)
+        if obj_type.meta.built_in:
+            raise Arcor2Exception("Can't delete built-in type.")
 
-    evt = sevts.o.ChangedObjectTypes([obj_type.meta])
-    evt.change_type = events.Event.Type.REMOVE
-    asyncio.ensure_future(notif.broadcast_event(evt))
+        for obj in glob.OBJECT_TYPES.values():
+            if obj.meta.base == req.args.id:
+                raise Arcor2Exception(f"Object type is base of '{obj.meta.type}'.")
+
+        async for scene in scenes():
+            check_scene_for_object_type(scene, req.args.id)
+
+        if glob.LOCK.scene:
+            check_scene_for_object_type(glob.LOCK.scene, req.args.id)
+
+        if req.dry_run:
+            return
+
+        await storage.delete_object_type(req.args.id)
+
+        # do not care so much if delete_model fails
+        if obj_type.meta.object_model:
+            try:
+                await storage.delete_model(obj_type.meta.object_model.model().id)
+            except storage.ProjectServiceException as e:
+                glob.logger.error(str(e))
+
+        del glob.OBJECT_TYPES[req.args.id]
+        remove_object_type(req.args.id)
+
+        evt = sevts.o.ChangedObjectTypes([obj_type.meta])
+        evt.change_type = events.Event.Type.REMOVE
+        asyncio.ensure_future(notif.broadcast_event(evt))
 
 
 def check_override(obj_id: str, override: Parameter, add_new_one: bool = False) -> SceneObject:
 
-    assert glob.SCENE
-    assert glob.PROJECT
+    assert glob.LOCK.scene
+    assert glob.LOCK.project
 
-    obj = glob.SCENE.object(obj_id)
+    obj = glob.LOCK.scene.object(obj_id)
 
     for par in glob.OBJECT_TYPES[obj.type].meta.settings:
         if par.name == override.name:
@@ -326,16 +343,16 @@ def check_override(obj_id: str, override: Parameter, add_new_one: bool = False) 
 
     if add_new_one:
         try:
-            for existing_override in glob.PROJECT.overrides[obj.id]:
+            for existing_override in glob.LOCK.project.overrides[obj.id]:
                 if override.name == existing_override.name:
                     raise Arcor2Exception("Override already exists.")
         except KeyError:
             pass
     else:
-        if obj.id not in glob.PROJECT.overrides:
+        if obj.id not in glob.LOCK.project.overrides:
             raise Arcor2Exception("There are no overrides for the object.")
 
-        for override in glob.PROJECT.overrides[obj.id]:
+        for override in glob.LOCK.project.overrides[obj.id]:
             if override.name == override.name:
                 break
         else:
@@ -347,18 +364,20 @@ def check_override(obj_id: str, override: Parameter, add_new_one: bool = False) 
 @project_needed
 async def add_override_cb(req: srpc.o.AddOverride.Request, ui: WsClient) -> None:
 
-    assert glob.PROJECT
+    assert glob.LOCK.project
 
     obj = check_override(req.args.id, req.args.override, add_new_one=True)
+
+    await ensure_locked(req.args.id, ui)
 
     if req.dry_run:
         return
 
-    if obj.id not in glob.PROJECT.overrides:
-        glob.PROJECT.overrides[obj.id] = []
+    if obj.id not in glob.LOCK.project.overrides:
+        glob.LOCK.project.overrides[obj.id] = []
 
-    glob.PROJECT.overrides[obj.id].append(req.args.override)
-    glob.PROJECT.update_modified()
+    glob.LOCK.project.overrides[obj.id].append(req.args.override)
+    glob.LOCK.project.update_modified()
 
     evt = sevts.o.OverrideUpdated(req.args.override)
     evt.change_type = events.Event.Type.ADD
@@ -369,17 +388,19 @@ async def add_override_cb(req: srpc.o.AddOverride.Request, ui: WsClient) -> None
 @project_needed
 async def update_override_cb(req: srpc.o.UpdateOverride.Request, ui: WsClient) -> None:
 
-    assert glob.PROJECT
+    assert glob.LOCK.project
 
     obj = check_override(req.args.id, req.args.override)
+
+    await ensure_locked(req.args.id, ui)
 
     if req.dry_run:
         return
 
-    for override in glob.PROJECT.overrides[obj.id]:
+    for override in glob.LOCK.project.overrides[obj.id]:
         if override.name == override.name:
             override.value = req.args.override.value
-    glob.PROJECT.update_modified()
+    glob.LOCK.project.update_modified()
 
     evt = sevts.o.OverrideUpdated(req.args.override)
     evt.change_type = events.Event.Type.UPDATE
@@ -390,19 +411,23 @@ async def update_override_cb(req: srpc.o.UpdateOverride.Request, ui: WsClient) -
 @project_needed
 async def delete_override_cb(req: srpc.o.DeleteOverride.Request, ui: WsClient) -> None:
 
-    assert glob.PROJECT
+    assert glob.LOCK.project
 
     obj = check_override(req.args.id, req.args.override)
+
+    await ensure_locked(req.args.id, ui)
 
     if req.dry_run:
         return
 
-    glob.PROJECT.overrides[obj.id] = [ov for ov in glob.PROJECT.overrides[obj.id] if ov.name != req.args.override.name]
+    glob.LOCK.project.overrides[obj.id] = [
+        ov for ov in glob.LOCK.project.overrides[obj.id] if ov.name != req.args.override.name
+    ]
 
-    if not glob.PROJECT.overrides[obj.id]:
-        del glob.PROJECT.overrides[obj.id]
+    if not glob.LOCK.project.overrides[obj.id]:
+        del glob.LOCK.project.overrides[obj.id]
 
-    glob.PROJECT.update_modified()
+    glob.LOCK.project.update_modified()
 
     evt = sevts.o.OverrideUpdated(req.args.override)
     evt.change_type = events.Event.Type.REMOVE

--- a/src/python/arcor2_arserver/rpc/user.py
+++ b/src/python/arcor2_arserver/rpc/user.py
@@ -1,0 +1,20 @@
+from websockets.server import WebSocketServerProtocol as WsClient
+
+from arcor2_arserver import globals as glob
+from arcor2_arserver.lock.structures import LockEventData
+from arcor2_arserver_data import rpc as srpc
+
+
+async def register_user_cb(req: srpc.u.RegisterUser.Request, ui: WsClient) -> None:
+    glob.USERS.login(req.args.user_name, ui)
+    await glob.LOCK.cancel_auto_release(req.args.user_name)
+
+    for user, user_objects in glob.LOCK.all_ui_locks.items():
+        if user != req.args.user_name:
+            glob.LOCK.notifications_q.put_nowait(LockEventData(list(user_objects), user, True, ui))
+
+    _, user_write_locks = await glob.LOCK.get_owner_locks(req.args.user_name)
+    if user_write_locks:
+        glob.LOCK.notifications_q.put_nowait(LockEventData(list(user_write_locks), req.args.user_name, True, ui))
+
+    return None

--- a/src/python/arcor2_arserver/tests/conftest.py
+++ b/src/python/arcor2_arserver/tests/conftest.py
@@ -142,6 +142,11 @@ for mod in modules:
 def ars() -> Iterator[ARServer]:
 
     with ARServer(ars_connection_str(), timeout=30, event_mapping=event_mapping) as ws:
+        test_username = "testUser"
+        assert ws.call_rpc(
+            rpc.u.RegisterUser.Request(uid(), rpc.u.RegisterUser.Request.Args(test_username)),
+            rpc.u.RegisterUser.Response,
+        ).result
         yield ws
 
 
@@ -252,3 +257,22 @@ def close_project(ars: ARServer) -> None:
 
     assert ars.call_rpc(rpc.p.CloseProject.Request(uid()), rpc.p.CloseProject.Response).result
     event(ars, events.p.ProjectClosed)
+
+
+def lock_object(ars: ARServer, obj_id: str, lock_tree: bool = False) -> None:
+
+    assert ars.call_rpc(
+        rpc.lock.WriteLock.Request(uid(), rpc.lock.WriteLock.Request.Args(obj_id, lock_tree)),
+        rpc.lock.WriteLock.Response,
+    )
+
+    event(ars, events.lk.ObjectsLocked)
+
+
+def unlock_object(ars: ARServer, obj_id: str) -> None:
+
+    assert ars.call_rpc(
+        rpc.lock.WriteUnlock.Request(uid(), rpc.lock.WriteUnlock.Request.Args(obj_id)), rpc.lock.WriteUnlock.Response
+    )
+
+    event(ars, events.lk.ObjectsUnlocked)

--- a/src/python/arcor2_arserver/tests/test_conditions.py
+++ b/src/python/arcor2_arserver/tests/test_conditions.py
@@ -2,7 +2,7 @@ import json
 
 from arcor2.data.common import Flow, FlowTypes, LogicItem, Position, ProjectLogicIf, Scene
 from arcor2.data.rpc.common import IdArgs
-from arcor2_arserver.tests.conftest import add_logic_item, event, save_project
+from arcor2_arserver.tests.conftest import add_logic_item, event, lock_object, save_project
 from arcor2_arserver.tests.objects.object_with_actions import ObjectWithActions
 from arcor2_arserver_data import events, rpc
 from arcor2_arserver_data.client import ARServer, uid
@@ -72,9 +72,19 @@ def test_object_parameters(start_processes: None, ars: ARServer, scene: Scene) -
     assert a2 is not None
 
     add_logic_item(ars, LogicItem.START, a1.id)
+    event(ars, events.lk.ObjectsUnlocked)
+
+    lock_object(ars, a1.id)
     add_logic_item(ars, a1.id, a2.id, ProjectLogicIf(f"{a1.id}/{FlowTypes.DEFAULT}/{0}", json.dumps(True)))
+    event(ars, events.lk.ObjectsUnlocked)
+
+    lock_object(ars, a2.id)
     add_logic_item(ars, a2.id, LogicItem.END)
+    event(ars, events.lk.ObjectsUnlocked)
+
+    lock_object(ars, a1.id)
     add_logic_item(ars, a1.id, LogicItem.END, ProjectLogicIf(f"{a1.id}/{FlowTypes.DEFAULT}/{0}", json.dumps(False)))
+    event(ars, events.lk.ObjectsUnlocked)
 
     # TODO try to add some invalid connections here?
 

--- a/src/python/arcor2_arserver/tests/test_lock.py
+++ b/src/python/arcor2_arserver/tests/test_lock.py
@@ -1,0 +1,113 @@
+import asyncio
+
+import pytest
+
+from arcor2.exceptions import Arcor2Exception
+from arcor2_arserver.globals import LOCK as lock
+from arcor2_arserver.lock.exceptions import CannotLock, LockingException
+
+
+@pytest.mark.asyncio()
+async def test_lock_basic() -> None:
+    test = "test"
+
+    # locking scene name
+    scene_id = lock.SpecialValues.SCENE_NAME
+    await lock.read_lock(scene_id, test)
+    assert scene_id in lock._locked_objects
+    assert scene_id in lock._locked_objects[scene_id].read
+    await lock.read_unlock(scene_id, test)
+    assert not lock._locked_objects
+
+    # locking project name
+    project_id = lock.SpecialValues.PROJECT_NAME
+    await lock.write_lock(project_id, test)
+    assert project_id in lock._locked_objects
+    assert project_id in lock._locked_objects[project_id].write
+    await lock.write_unlock(project_id, test)
+    assert not lock._locked_objects
+
+    # exception expected when locking unknown object type
+    with pytest.raises(Arcor2Exception):
+        await lock.read_lock(test, test)
+    assert not lock._locked_objects
+
+    with pytest.raises(Arcor2Exception):
+        await lock.write_lock(test, test)
+    assert not lock._locked_objects
+
+    # exception expected when unlocking unknown object type
+    with pytest.raises(Arcor2Exception):
+        await lock.read_unlock(test, test)
+
+    with pytest.raises(Arcor2Exception):
+        await lock.write_unlock(test, test)
+
+    # exception expected when unlocking not locked object
+    with pytest.raises(LockingException):
+        await lock.read_unlock(scene_id, test)
+
+    with pytest.raises(LockingException):
+        await lock.write_unlock(scene_id, test)
+
+    with pytest.raises(LockingException):
+        await lock.read_unlock(project_id, test)
+
+    with pytest.raises(LockingException):
+        await lock.write_unlock(project_id, test)
+
+    assert not lock._locked_objects
+
+    # test whole lock yield
+    async with lock.get_lock() as val:
+        assert isinstance(val, asyncio.Lock)
+        with pytest.raises(CannotLock):
+            async with lock.get_lock():
+                pass
+        assert lock._lock.locked()
+
+    async with lock.get_lock(dry_run=True) as val:
+        assert val is None
+
+    await lock.write_lock(scene_id, test)
+    with pytest.raises(CannotLock):
+        async with lock.get_lock():
+            pass
+    await lock.write_unlock(scene_id, test)
+
+    # locking already locked object
+    assert not await lock.is_write_locked(scene_id, test)
+    await lock.write_lock(scene_id, test)
+    assert await lock.is_write_locked(scene_id, test)
+    assert not await lock.is_read_locked(scene_id, test)
+    assert not await lock.write_lock(scene_id, test)
+    await lock.write_unlock(scene_id, test)
+
+    assert not await lock.is_read_locked(scene_id, test)
+    await lock.read_lock(scene_id, test)
+    assert await lock.is_read_locked(scene_id, test)
+    assert not await lock.is_write_locked(scene_id, test)
+    assert await lock.read_lock(scene_id, test)
+    await lock.read_unlock(scene_id, test)
+    assert not await lock.write_lock(scene_id, test)
+    await lock.read_unlock(scene_id, test)
+
+    # testing count returning methods
+    assert await lock.get_locked_roots_count() == 0
+    assert await lock.get_write_locks_count() == 0
+    await lock.write_lock(scene_id, test)
+    assert await lock.get_locked_roots_count() == 1
+    assert await lock.get_write_locks_count() == 1
+    await lock.write_unlock(scene_id, test)
+
+
+# @pytest.mark.asyncio()
+# def test_lock_with_scene(scene: common.Scene) -> None:
+#     # test locking with active scene
+#     ...
+#
+#
+# @pytest.mark.asyncio()
+# def test_lock_with_project(project: common.Project) -> None:
+#     # test locking with prefilled all project objects
+#     ...

--- a/src/python/arcor2_arserver/tests/test_project_execution.py
+++ b/src/python/arcor2_arserver/tests/test_project_execution.py
@@ -2,7 +2,15 @@ from arcor2.clients import persistent_storage
 from arcor2.data import common
 from arcor2.data import events as arcor2_events
 from arcor2.object_types.time_actions import TimeActions
-from arcor2_arserver.tests.conftest import LOGGER, add_logic_item, close_project, event, save_project, wait_for_event
+from arcor2_arserver.tests.conftest import (
+    LOGGER,
+    add_logic_item,
+    close_project,
+    event,
+    lock_object,
+    save_project,
+    wait_for_event,
+)
 from arcor2_arserver_data import events, rpc
 from arcor2_arserver_data.client import ARServer, uid
 from arcor2_execution_data import events as eevents
@@ -65,7 +73,11 @@ def test_run_simple_project(start_processes: None, ars: ARServer) -> None:
     assert action is not None
 
     add_logic_item(ars, common.LogicItem.START, action.id)
+    event(ars, events.lk.ObjectsUnlocked)
+
+    lock_object(ars, action.id)
     add_logic_item(ars, action.id, common.LogicItem.END)
+    event(ars, events.lk.ObjectsUnlocked)
 
     save_project(ars)
 

--- a/src/python/arcor2_arserver/user.py
+++ b/src/python/arcor2_arserver/user.py
@@ -1,0 +1,43 @@
+from typing import Dict, Set
+
+from websockets.server import WebSocketServerProtocol as WsClient
+
+from arcor2.exceptions import Arcor2Exception
+
+
+class Users:
+    def __init__(self) -> None:
+
+        self._interfaces: Set[WsClient] = set()
+        self._users_ui: Dict[str, int] = {}
+        self._ui_users: Dict[int, str] = {}
+
+    @property
+    def interfaces(self) -> Set[WsClient]:
+        return self._interfaces
+
+    def add_interface(self, ui: WsClient) -> None:
+        self._interfaces.add(ui)
+
+    def login(self, user_name: str, ui: WsClient) -> None:
+
+        if user_name in self._users_ui:
+            raise Arcor2Exception("Username already exists")
+
+        ui_id = id(ui)
+        self._ui_users[ui_id] = user_name
+        self._users_ui[user_name] = ui_id
+
+    def logout(self, ui: WsClient) -> None:
+
+        self._interfaces.remove(ui)
+        try:
+            user_name = self._ui_users[id(ui)]
+            del self._users_ui[user_name]
+            del self._ui_users[id(ui)]
+        except KeyError:  # Login request is after socket registration, UI not registered when login fails
+            ...
+
+    def user_name(self, ui: WsClient) -> str:
+
+        return self._ui_users[id(ui)]

--- a/src/python/arcor2_arserver_data/events/__init__.py
+++ b/src/python/arcor2_arserver_data/events/__init__.py
@@ -1,8 +1,9 @@
 from arcor2_arserver_data.events import actions as a
 from arcor2_arserver_data.events import common as c
+from arcor2_arserver_data.events import lock as lk
 from arcor2_arserver_data.events import objects as o
 from arcor2_arserver_data.events import project as p
 from arcor2_arserver_data.events import robot as r
 from arcor2_arserver_data.events import scene as s
 
-__all__ = [a.__name__, c.__name__, o.__name__, p.__name__, r.__name__, s.__name__]
+__all__ = [a.__name__, c.__name__, o.__name__, p.__name__, r.__name__, s.__name__, lk.__name__]

--- a/src/python/arcor2_arserver_data/events/lock.py
+++ b/src/python/arcor2_arserver_data/events/lock.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import List
+
+from dataclasses_jsonschema import JsonSchemaMixin
+
+from arcor2.data.events import Event
+
+
+@dataclass
+class LockData(JsonSchemaMixin):
+
+    object_ids: List[str]
+    owner: str
+
+
+@dataclass
+class ObjectsLocked(Event):
+
+    data: LockData
+
+
+@dataclass
+class ObjectsUnlocked(Event):
+
+    data: LockData

--- a/src/python/arcor2_arserver_data/rpc/__init__.py
+++ b/src/python/arcor2_arserver_data/rpc/__init__.py
@@ -1,8 +1,10 @@
 from arcor2_arserver_data.rpc import build as b
 from arcor2_arserver_data.rpc import common as c
+from arcor2_arserver_data.rpc import lock
 from arcor2_arserver_data.rpc import objects as o
 from arcor2_arserver_data.rpc import project as p
 from arcor2_arserver_data.rpc import robot as r
 from arcor2_arserver_data.rpc import scene as s
+from arcor2_arserver_data.rpc import user as u
 
-__all__ = [b.__name__, c.__name__, o.__name__, p.__name__, r.__name__, s.__name__]
+__all__ = [b.__name__, c.__name__, o.__name__, p.__name__, r.__name__, s.__name__, lock.__name__, u.__name__]

--- a/src/python/arcor2_arserver_data/rpc/lock.py
+++ b/src/python/arcor2_arserver_data/rpc/lock.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+
+from dataclasses_jsonschema import JsonSchemaMixin
+
+from arcor2.data.rpc.common import RPC
+
+
+class ReadLock(RPC):
+    @dataclass
+    class Request(RPC.Request):
+        @dataclass
+        class Args(JsonSchemaMixin):
+            object_id: str
+
+        args: Args
+
+    @dataclass
+    class Response(RPC.Response):
+        pass
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class WriteLock(RPC):
+    @dataclass
+    class Request(RPC.Request):
+        @dataclass
+        class Args(JsonSchemaMixin):
+            object_id: str
+            lock_tree: bool = False
+
+        args: Args
+
+    @dataclass
+    class Response(RPC.Response):
+        pass
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class ReadUnlock(RPC):
+    @dataclass
+    class Request(RPC.Request):
+        @dataclass
+        class Args(JsonSchemaMixin):
+            object_id: str
+
+        args: Args
+
+    @dataclass
+    class Response(RPC.Response):
+        pass
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class WriteUnlock(RPC):
+    @dataclass
+    class Request(RPC.Request):
+        @dataclass
+        class Args(JsonSchemaMixin):
+            object_id: str
+
+        args: Args
+
+    @dataclass
+    class Response(RPC.Response):
+        pass

--- a/src/python/arcor2_arserver_data/rpc/project.py
+++ b/src/python/arcor2_arserver_data/rpc/project.py
@@ -50,7 +50,8 @@ class CloseProject(RPC):
 class SaveProject(RPC):
     @dataclass
     class Request(RPC.Request):
-        pass
+
+        dry_run: bool = False
 
     @dataclass
     class Response(RPC.Response):

--- a/src/python/arcor2_arserver_data/rpc/scene.py
+++ b/src/python/arcor2_arserver_data/rpc/scene.py
@@ -92,7 +92,8 @@ class RemoveFromScene(RPC):
 class SaveScene(RPC):
     @dataclass
     class Request(RPC.Request):
-        pass
+
+        dry_run: bool = False
 
     @dataclass
     class Response(RPC.Response):

--- a/src/python/arcor2_arserver_data/rpc/user.py
+++ b/src/python/arcor2_arserver_data/rpc/user.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from dataclasses_jsonschema import JsonSchemaMixin
+
+from arcor2.data.rpc.common import RPC
+
+
+class RegisterUser(RPC):
+    @dataclass
+    class Request(RPC.Request):
+        @dataclass
+        class Args(JsonSchemaMixin):
+            user_name: str
+
+        args: Args
+
+    @dataclass
+    class Response(RPC.Response):
+        pass


### PR DESCRIPTION
## [0.16.1] - 2021-04-26
### Added
- Created a lock module that allows to read/write lock existing or special objects.
- The module contains:
  - lock object with all necessary methods;
  - structures for keeping data about locked objects;
  - locking-related exceptions;
  - queue and task for notifying UI about lock data;
  - methods for auto-unlocking after timeout when user logouts.
- Base tests of locking structure.
- RPCs for (un)locking object, registering user name.
- Events for (un)locking object.
- Created a class for maintaining connected UIs.
- Project methods to get object by ID, object parent and object children.

### Changed
- All RPCs that requires some kind of locking are now lock-guarded.
- Updated existing tests to work with newly implemented locking.
- Global variables `SCENE`, `PROJECT` and `INTERFACES` moved to new classes.