### PR TITLE
feat(arcor2_arserver): get rid of decorators and asserts

### DIFF
--- a/src/python/arcor2/helpers.py
+++ b/src/python/arcor2/helpers.py
@@ -83,9 +83,9 @@ def save_and_import_type_def(source: str, type_name: str, output_type: Type[T], 
     """
 
     type_file = humps.depascalize(type_name)
-    full_path = os.path.join(path, module_name, type_file)
+    full_path = f"{os.path.join(path, module_name, type_file)}.py"
 
-    with open(f"{full_path}.py", "w") as file:
+    with open(full_path, "w") as file:
         file.write(source)
 
     try:

--- a/src/python/arcor2_arserver/decorators.py
+++ b/src/python/arcor2_arserver/decorators.py
@@ -2,54 +2,9 @@ import functools
 from asyncio import sleep
 from typing import Any, Callable, Coroutine, Type, TypeVar, cast
 
-from arcor2.exceptions import Arcor2Exception
-from arcor2_arserver import globals as glob
 from arcor2_arserver.lock.exceptions import LockingException
 
 F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, Any]])
-
-
-def no_scene(coro: F) -> F:
-    @functools.wraps(coro)
-    async def async_wrapper(*args, **kwargs) -> Any:
-
-        if glob.LOCK.scene:
-            raise Arcor2Exception("Scene has to be closed first.")
-        return await coro(*args, **kwargs)
-
-    return cast(F, async_wrapper)
-
-
-def scene_needed(coro: F) -> F:
-    @functools.wraps(coro)
-    async def async_wrapper(*args, **kwargs) -> Any:
-
-        if glob.LOCK.scene is None or not glob.LOCK.scene.id:
-            raise Arcor2Exception("Scene not opened or has invalid id.")
-        return await coro(*args, **kwargs)
-
-    return cast(F, async_wrapper)
-
-
-def no_project(coro: F) -> F:
-    @functools.wraps(coro)
-    async def async_wrapper(*args, **kwargs) -> Any:
-        if glob.LOCK.project:
-            raise Arcor2Exception("Not available during project editing.")
-        return await coro(*args, **kwargs)
-
-    return cast(F, async_wrapper)
-
-
-def project_needed(coro: F) -> F:
-    @functools.wraps(coro)
-    async def async_wrapper(*args, **kwargs) -> Any:
-
-        if glob.LOCK.project is None or not glob.LOCK.project.id:
-            raise Arcor2Exception("Project not opened or has invalid id.")
-        return await coro(*args, **kwargs)
-
-    return cast(F, async_wrapper)
 
 
 def retry(exc: Type[Exception] = LockingException, tries: int = 1, delay: float = 0) -> Callable:

--- a/src/python/arcor2_arserver/execution.py
+++ b/src/python/arcor2_arserver/execution.py
@@ -70,7 +70,7 @@ async def run_temp_package(package_id: str) -> None:
     )
 
     if scene_online:
-        await start_scene()
+        await start_scene(glob.LOCK.scene)
 
 
 async def build_and_upload_package(project_id: str, package_name: str) -> str:

--- a/src/python/arcor2_arserver/lock/lock.py
+++ b/src/python/arcor2_arserver/lock/lock.py
@@ -43,6 +43,15 @@ class Lock:
     def scene(self, scene: Optional[UpdateableCachedScene] = None) -> None:
         self._scene = scene
 
+    def scene_or_exception(self, ensure_project_closed: bool = False) -> UpdateableCachedScene:
+        if not self._scene:
+            raise Arcor2Exception("Scene not opened.")
+
+        if ensure_project_closed and self._project:
+            raise Arcor2Exception("Project has to be closed first.")
+
+        return self._scene
+
     @property
     def project(self) -> Optional[UpdateableCachedProject]:
         return self._project
@@ -50,6 +59,12 @@ class Lock:
     @project.setter
     def project(self, project: Optional[UpdateableCachedProject] = None) -> None:
         self._project = project
+
+    def project_or_exception(self) -> UpdateableCachedProject:
+        if not self._project:
+            raise Arcor2Exception("Project not opened.")
+
+        return self._project
 
     @property
     def all_ui_locks(self) -> Dict[str, Set[str]]:
@@ -259,6 +274,7 @@ class Lock:
     async def get_locked_roots_count(self) -> int:
 
         async with self._lock:
+            print(self._locked_objects)
             return len(self._locked_objects)
 
     async def get_write_locks_count(self) -> int:

--- a/src/python/arcor2_arserver/objects_actions.py
+++ b/src/python/arcor2_arserver/objects_actions.py
@@ -3,6 +3,7 @@ import os
 from typing import List, Optional, Set, Type, Union
 
 from arcor2 import helpers as hlp
+from arcor2.cached import CachedScene
 from arcor2.clients import aio_persistent_storage as ps
 from arcor2.data.events import Event
 from arcor2.data.object_type import ObjectModel
@@ -37,20 +38,10 @@ def get_types_dict() -> TypesDict:
     return {k: v.type_def for k, v in glob.OBJECT_TYPES.items() if v.type_def is not None}
 
 
-def get_obj_type_name(object_id: str) -> str:
-
-    assert glob.LOCK.scene
+def get_obj_type_data(scene: CachedScene, object_id: str) -> ObjectTypeData:
 
     try:
-        return glob.LOCK.scene.object(object_id).type
-    except KeyError:
-        raise Arcor2Exception("Unknown object id.")
-
-
-def get_obj_type_data(object_id: str) -> ObjectTypeData:
-
-    try:
-        return glob.OBJECT_TYPES[get_obj_type_name(object_id)]
+        return glob.OBJECT_TYPES[scene.object(object_id).type]
     except KeyError:
         raise Arcor2Exception("Unknown object type.")
 

--- a/src/python/arcor2_arserver/robot.py
+++ b/src/python/arcor2_arserver/robot.py
@@ -3,6 +3,7 @@ from ast import AST
 from typing import List, Optional, Set, Type
 
 import arcor2.helpers as hlp
+from arcor2.cached import CachedScene
 from arcor2.data import common
 from arcor2.exceptions import Arcor2Exception
 from arcor2.object_types.abstract import Robot
@@ -155,9 +156,11 @@ async def fk(robot_id: str, end_effector_id: str, joints: List[common.Joint]) ->
     return await hlp.run_in_executor(robot_inst.forward_kinematics, end_effector_id, joints)
 
 
-async def check_reachability(robot_id: str, end_effector_id: str, pose: common.Pose, safe: bool = True) -> None:
+async def check_reachability(
+    scene: CachedScene, robot_id: str, end_effector_id: str, pose: common.Pose, safe: bool = True
+) -> None:
 
-    otd = osa.get_obj_type_data(robot_id)
+    otd = osa.get_obj_type_data(scene, robot_id)
     if otd.robot_meta and otd.robot_meta.features.inverse_kinematics:
         try:
             await ik(robot_id, end_effector_id, pose, avoid_collisions=safe)

--- a/src/python/arcor2_arserver/rpc/camera.py
+++ b/src/python/arcor2_arserver/rpc/camera.py
@@ -3,6 +3,7 @@ import asyncio
 from arcor2_calibration_data import client as calib_client
 from websockets.server import WebSocketServerProtocol as WsClient
 
+from arcor2.cached import UpdateableCachedScene
 from arcor2.exceptions import Arcor2Exception
 from arcor2.helpers import run_in_executor
 from arcor2.image import image_to_str
@@ -10,17 +11,15 @@ from arcor2.object_types.abstract import Camera
 from arcor2_arserver import globals as glob
 from arcor2_arserver import notifications as notif
 from arcor2_arserver.camera import get_camera_instance
-from arcor2_arserver.decorators import scene_needed
 from arcor2_arserver.helpers import ensure_locked
 from arcor2_arserver.scene import ensure_scene_started, update_scene_object_pose
 from arcor2_arserver_data.events.common import ProcessState
 from arcor2_arserver_data.rpc.camera import CalibrateCamera, CameraColorImage, CameraColorParameters
 
 
-@scene_needed
 async def camera_color_image_cb(req: CameraColorImage.Request, ui: WsClient) -> CameraColorImage.Response:
 
-    assert glob.LOCK.scene
+    glob.LOCK.scene_or_exception()
 
     await ensure_locked(req.args.id, ui)
 
@@ -31,12 +30,11 @@ async def camera_color_image_cb(req: CameraColorImage.Request, ui: WsClient) -> 
     return resp
 
 
-@scene_needed
 async def camera_color_parameters_cb(
     req: CameraColorParameters.Request, ui: WsClient
 ) -> CameraColorParameters.Response:
 
-    assert glob.LOCK.scene
+    glob.LOCK.scene_or_exception()
 
     await ensure_locked(req.args.id, ui)
 
@@ -50,10 +48,9 @@ async def camera_color_parameters_cb(
 CAMERA_CALIB = "CameraCalibration"
 
 
-async def calibrate_camera(camera: Camera) -> None:
+async def calibrate_camera(scene: UpdateableCachedScene, camera: Camera) -> None:
 
     assert camera.color_camera_params
-    assert glob.LOCK.scene
 
     await notif.broadcast_event(ProcessState(ProcessState.Data(CAMERA_CALIB, ProcessState.Data.StateEnum.Started)))
     try:
@@ -66,14 +63,13 @@ async def calibrate_camera(camera: Camera) -> None:
         glob.logger.exception("Failed to calibrate the camera.")
         return
 
-    await update_scene_object_pose(glob.LOCK.scene.object(camera.id), estimated_pose.pose, camera)
+    await update_scene_object_pose(scene, scene.object(camera.id), estimated_pose.pose, camera)
     await notif.broadcast_event(ProcessState(ProcessState.Data(CAMERA_CALIB, ProcessState.Data.StateEnum.Finished)))
 
 
-@scene_needed
 async def calibrate_camera_cb(req: CalibrateCamera.Request, ui: WsClient) -> None:
 
-    assert glob.LOCK.scene
+    scene = glob.LOCK.scene_or_exception()
 
     ensure_scene_started()
     camera = get_camera_instance(req.args.id)
@@ -84,4 +80,4 @@ async def calibrate_camera_cb(req: CalibrateCamera.Request, ui: WsClient) -> Non
 
     await ensure_locked(req.args.id, ui)
 
-    asyncio.ensure_future(calibrate_camera(camera))
+    asyncio.ensure_future(calibrate_camera(scene, camera))


### PR DESCRIPTION
- Scene/project within RPC callbacks is now obtained using a method call.
- Context lock added to `CloseScene` RPC.