### PR TITLE
feat: support for multiple inheritance

### DIFF
--- a/src/python/arcor2/helpers.py
+++ b/src/python/arcor2/helpers.py
@@ -130,7 +130,7 @@ def import_type_def(type_name: str, output_type: Type[T], path: str, module_name
         raise ImportClsException(f"Class {type_name} not found in module '{module_name}'.")
 
     if not issubclass(cls, output_type):
-        raise ImportClsException("Not a required type.")
+        raise ImportClsException(f"{cls.__name__} is not subclass of {output_type.__name__}.")
 
     return cls
 

--- a/src/python/arcor2/object_types/upload.py
+++ b/src/python/arcor2/object_types/upload.py
@@ -20,6 +20,13 @@ class Urdf(NamedTuple):
     archive_name: str
 
 
+def upload_whatever(type_def: Type[object]) -> None:
+
+    obj_type = ObjectType(id=type_def.__name__, source=get_containing_module_sources(type_def))
+    print(f"Storing '{obj_type.id}'...")
+    storage.update_object_type(obj_type)
+
+
 def upload_def(type_def: Type[Generic], model: Optional[Models] = None, urdf: Optional[Urdf] = None) -> None:
 
     if not issubclass(type_def, GenericWithPose) and model:

--- a/src/python/arcor2_fit_demo/object_types/abstract_dobot.py
+++ b/src/python/arcor2_fit_demo/object_types/abstract_dobot.py
@@ -5,13 +5,14 @@ from arcor2 import DynamicParamTuple as DPT
 from arcor2 import rest
 from arcor2.data.common import ActionMetadata, Joint, Pose, StrEnum
 from arcor2.data.robot import RobotType
-from arcor2.object_types.abstract import Robot, RobotException, Settings
+from arcor2.object_types.abstract import Robot, RobotException
+
+from .fit_common_mixin import FitCommonMixin, UrlSettings
 
 
 @dataclass
-class DobotSettings(Settings):
+class DobotSettings(UrlSettings):
 
-    url: str
     port: str = "/dev/dobot"
 
 
@@ -26,18 +27,12 @@ class MoveType(StrEnum):
     LINEAR: str = "LINEAR"
 
 
-class AbstractDobot(Robot):
+class AbstractDobot(FitCommonMixin, Robot):
 
     robot_type = RobotType.SCARA
 
     def __init__(self, obj_id: str, name: str, pose: Pose, settings: DobotSettings) -> None:
         super(AbstractDobot, self).__init__(obj_id, name, pose, settings)
-
-    def _started(self) -> bool:
-        return rest.call(rest.Method.GET, f"{self.settings.url}/started", return_type=bool)
-
-    def _stop(self) -> None:
-        rest.call(rest.Method.PUT, f"{self.settings.url}/stop")
 
     def _start(self, model: str) -> None:
 
@@ -52,7 +47,7 @@ class AbstractDobot(Robot):
         )
 
     @property
-    def settings(self) -> DobotSettings:
+    def settings(self) -> DobotSettings:  # type: ignore
         return cast(DobotSettings, super(AbstractDobot, self).settings)
 
     def cleanup(self):

--- a/src/python/arcor2_fit_demo/object_types/fit_common_mixin.py
+++ b/src/python/arcor2_fit_demo/object_types/fit_common_mixin.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from arcor2 import rest
+from arcor2.object_types.abstract import Settings
+
+
+@dataclass
+class UrlSettings(Settings):
+
+    url: str
+
+
+class FitCommonMixin:
+
+    if TYPE_CHECKING:
+        settings = UrlSettings("")
+
+    def _started(self) -> bool:
+        return rest.call(rest.Method.GET, f"{self.settings.url}/started", return_type=bool)
+
+    def _stop(self) -> None:
+        rest.call(rest.Method.PUT, f"{self.settings.url}/stop")

--- a/src/python/arcor2_fit_demo/object_types/kinect_azure.py
+++ b/src/python/arcor2_fit_demo/object_types/kinect_azure.py
@@ -1,6 +1,5 @@
-from dataclasses import dataclass
 from io import BytesIO
-from typing import Optional, cast
+from typing import Optional
 
 from PIL import Image
 
@@ -9,15 +8,11 @@ from arcor2.data.camera import CameraParameters
 from arcor2.data.common import ActionMetadata, Pose
 from arcor2.data.object_type import Models
 from arcor2.object_types.abstract import Camera
-from arcor2.object_types.abstract import Settings as BaseSettings
+
+from .fit_common_mixin import FitCommonMixin, UrlSettings
 
 
-@dataclass
-class Settings(BaseSettings):
-    url: str
-
-
-class KinectAzure(Camera):
+class KinectAzure(FitCommonMixin, Camera):
 
     _ABSTRACT = False
 
@@ -27,7 +22,7 @@ class KinectAzure(Camera):
         name: str,
         pose: Pose,
         collision_model: Optional[Models] = None,
-        settings: Optional[Settings] = None,
+        settings: Optional[UrlSettings] = None,
     ) -> None:
 
         super(KinectAzure, self).__init__(obj_id, name, pose, collision_model, settings)
@@ -41,17 +36,11 @@ class KinectAzure(Camera):
         )
 
     @property
-    def settings(self) -> Settings:
-        return cast(Settings, super(KinectAzure, self).settings)
+    def settings(self) -> UrlSettings:  # type: ignore
+        return super(KinectAzure, self).settings
 
     def _start(self) -> None:
         rest.call(rest.Method.PUT, f"{self.settings.url}/state/start")
-
-    def _started(self) -> bool:
-        return rest.call(rest.Method.GET, f"{self.settings.url}/state/started", return_type=bool)
-
-    def _stop(self) -> None:
-        rest.call(rest.Method.PUT, f"{self.settings.url}/state/stop")
 
     def color_image(self, *, an: Optional[str] = None) -> Image.Image:
         return rest.get_image(f"{self.settings.url}/color/image")

--- a/src/python/arcor2_fit_demo/scripts/kinect_calibration.py
+++ b/src/python/arcor2_fit_demo/scripts/kinect_calibration.py
@@ -3,12 +3,12 @@ import time
 from arcor2_calibration_data import client as calib_client
 
 from arcor2.data.common import Pose
-from arcor2_fit_demo.object_types.kinect_azure import KinectAzure, Settings
+from arcor2_fit_demo.object_types.kinect_azure import KinectAzure, UrlSettings
 
 
 def main() -> None:
 
-    kinect = KinectAzure("", "", Pose(), settings=Settings("http://localhost:5016"))
+    kinect = KinectAzure("", "", Pose(), settings=UrlSettings("http://localhost:5016"))
     # print(kinect.color_camera_params)
     assert kinect.color_camera_params
     ci_start = time.monotonic()

--- a/src/python/arcor2_fit_demo/scripts/upload_objects.py
+++ b/src/python/arcor2_fit_demo/scripts/upload_objects.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
-from arcor2.object_types.upload import Urdf, upload_def
+from arcor2.object_types.upload import Urdf, upload_def, upload_whatever
 from arcor2_fit_demo import get_data
 from arcor2_fit_demo.object_types.abstract_dobot import AbstractDobot
 from arcor2_fit_demo.object_types.dobot_m1 import DobotM1
 from arcor2_fit_demo.object_types.dobot_magician import DobotMagician
+from arcor2_fit_demo.object_types.fit_common_mixin import FitCommonMixin
 from arcor2_fit_demo.object_types.kinect_azure import KinectAzure
 
 
@@ -14,6 +15,7 @@ def main() -> None:
     upload_def(DobotMagician, urdf=Urdf(get_data("dobot-magician"), DobotMagician.urdf_package_name))
     upload_def(DobotM1, urdf=Urdf(get_data("dobot-m1"), DobotM1.urdf_package_name))
     upload_def(KinectAzure)  # TODO add its mesh
+    upload_whatever(FitCommonMixin)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- ObjectTypes can now use mixins which are handled by ARServer and Build.
- It should be used like `class NewObjectType(MixinA, MixinB, Generic)`.
- E.g. the last ancestor should be something derived from `Generic`.