### PR TITLE
feat(arcor2_arserver): allow fast re-login after connection was broken

### DIFF
--- a/src/python/arcor2_arserver/rpc/user.py
+++ b/src/python/arcor2_arserver/rpc/user.py
@@ -7,7 +7,7 @@ from arcor2_arserver_data import rpc as srpc
 
 async def register_user_cb(req: srpc.u.RegisterUser.Request, ui: WsClient) -> None:
 
-    glob.USERS.login(req.args.user_name, ui)
+    await glob.USERS.login(req.args.user_name, ui)
     glob.logger.debug(f"User {req.args.user_name} just logged in. Known user names are: {glob.USERS.user_names}")
 
     await glob.LOCK.cancel_auto_release(req.args.user_name)

--- a/src/python/arcor2_arserver/user.py
+++ b/src/python/arcor2_arserver/user.py
@@ -1,5 +1,7 @@
+import asyncio
 from typing import Dict, Set
 
+from websockets.exceptions import WebSocketException
 from websockets.server import WebSocketServerProtocol as WsClient
 
 from arcor2.exceptions import Arcor2Exception
@@ -13,13 +15,14 @@ class Users:
     def __init__(self) -> None:
 
         self._interfaces: Set[WsClient] = set()
-        self._users_ui: Dict[str, int] = {}
-        self._ui_users: Dict[int, str] = {}
+        self._users_ui: Dict[str, WsClient] = {}
+        self._ui_users: Dict[WsClient, str] = {}
 
     def _assert_consistency(self) -> None:
 
         assert list(self._ui_users.keys()) == list(self._users_ui.values())
         assert list(self._ui_users.values()) == list(self._users_ui.keys())
+        assert set(self._ui_users).issubset(self._interfaces)
 
     @property
     def interfaces(self) -> Set[WsClient]:
@@ -28,17 +31,33 @@ class Users:
     def add_interface(self, ui: WsClient) -> None:
         self._interfaces.add(ui)
 
-    def login(self, user_name: str, ui: WsClient) -> None:
+    async def login(self, user_name: str, ui: WsClient) -> None:
 
         self._assert_consistency()
 
+        if not user_name:
+            raise UsersException("Empty user name.")
+
+        if ui not in self._interfaces:
+            raise UsersException("Unknown ui.")
+
         if user_name in self._users_ui:
-            raise UsersException("Username already exists")
 
-        ui_id = id(ui)
+            old_ui = self._users_ui[user_name]
 
-        self._ui_users[ui_id] = user_name
-        self._users_ui[user_name] = ui_id
+            try:
+                pong_waiter = await old_ui.ping()
+                await asyncio.wait_for(pong_waiter, 1.0)
+            except (WebSocketException, asyncio.TimeoutError):
+                self._users_ui.pop(user_name, None)
+                self._ui_users.pop(old_ui, None)
+            else:
+                raise UsersException("Username already exists")
+
+        self._ui_users[ui] = user_name
+        self._users_ui[user_name] = ui
+
+        self._assert_consistency()
 
     def logout(self, ui: WsClient) -> None:
         """Removes ui from known interfaces and logs a user out (if logged in).
@@ -54,25 +73,21 @@ class Users:
         except KeyError:
             raise UsersException("Unknown ui.")
 
-        ui_id = id(ui)
+        user_name = self._ui_users.pop(ui, None)
+        if user_name:
+            self._users_ui.pop(user_name, None)
 
-        try:
-            user_name = self._ui_users[ui_id]
-        except KeyError:
-            return
-
-        del self._users_ui[user_name]
-        del self._ui_users[ui_id]
+        self._assert_consistency()
 
     @property
     def user_names(self) -> Set[str]:
-        return set(self._users_ui.keys())
+        return set(self._users_ui)
 
     def user_name(self, ui: WsClient) -> str:
 
         self._assert_consistency()
 
         try:
-            return self._ui_users[id(ui)]
+            return self._ui_users[ui]
         except KeyError:
             raise UsersException("User not logged in.")


### PR DESCRIPTION
- When a user was logged in and the device e.g. lost connection, it was not possible to log in again with the same user name for 20 seconds.
- ARServer now tries if the stored connection still works and if not, it allows re-use of the user name.