### PR TITLE
feat(arcor2_kinali): update for Statistic Web API (0.6.0)

### DIFF
--- a/src/python/arcor2_kinali/object_types/statistic.py
+++ b/src/python/arcor2_kinali/object_types/statistic.py
@@ -17,20 +17,14 @@ class StatisticValue(JsonSchemaMixin):
 
 
 class Statistic(AbstractSimple):
-    """Statistic Web API Reference (0.4.0)."""
+    """Statistic Web API Reference (0.6.0)."""
 
     _ABSTRACT = False
 
-    def get_names(self, group_id: str, *, an: Optional[str] = None) -> List[str]:
-        """Gets names of all tracked values stored in given group.
-
-        :param group_id:
-        :return:
-        """
-        return rest.call(rest.Method.GET, f"{self.settings.url}/values/{group_id}", list_return_type=str)
-
     def add_value(self, group_id: str, name: str, value: float, *, an: Optional[str] = None) -> None:
-        """Logs value with the specified group and name.
+        """Adds value with the specified name and group. The timestamp of
+        creation is associated with added value. New group is created if
+        required.
 
         :param group_id:
         :param name:
@@ -52,23 +46,30 @@ class Statistic(AbstractSimple):
         return rest.call(rest.Method.GET, f"{self.settings.url}/values", list_return_type=str)
 
     def get_values(
-        self, group_id: str, name: str, since_timestamp: int = 0, *, an: Optional[str] = None
+        self,
+        group_id: str,
+        since_timestamp: int = 0,
+        values_count: int = -1,
+        samples_count: int = -1,
+        *,
+        an: Optional[str] = None,
     ) -> List[StatisticValue]:
         """Gets tracked values with the specified name. Values are sorted as
         were added to service.
 
         :param group_id: Logged value name.
-        :param name: Logged value name.
         :param since_timestamp: The date and time, as a UNIX timestamp in nanoseconds, after which created values
                                 are returned.
+        :param values_count: How many latest values to retrieve.
+        :param samples_count: How many samples from retrieved values to return.
         :return:
         """
 
         return rest.call(
             rest.Method.GET,
-            f"{self.settings.url}/values/{group_id}/{name}",
+            f"{self.settings.url}/values/{group_id}",
             list_return_type=StatisticValue,
-            params={"since_timestamp": since_timestamp},
+            params={"since_timestamp": since_timestamp, "values_count": values_count, "samples_count": samples_count},
         )
 
     def delete_group(self, group_id: str, *, an: Optional[str] = None) -> None:
@@ -80,7 +81,6 @@ class Statistic(AbstractSimple):
 
         rest.call(rest.Method.DELETE, f"{self.settings.url}/values/{group_id}")
 
-    get_names.__action__ = ActionMetadata(blocking=True)  # type: ignore
     add_value.__action__ = ActionMetadata(blocking=True)  # type: ignore
     get_groups.__action__ = ActionMetadata(blocking=True)  # type: ignore
     get_values.__action__ = ActionMetadata(blocking=True)  # type: ignore


### PR DESCRIPTION
Add `values_count` and `samples_count` filter fields for statistics endpoint

BREAKING CHANGE: drop endpoint for getting all names in group