### PR TITLE
feat: virtual collision objects

### DIFF
--- a/src/python/arcor2/data/object_type.py
+++ b/src/python/arcor2/data/object_type.py
@@ -92,6 +92,7 @@ class Mesh(Model):
 
 MeshList = List[Mesh]
 
+PrimitiveModels = Union[Box, Sphere, Cylinder]
 Models = Union[Box, Sphere, Cylinder, Mesh]
 
 MODEL_MAPPING: Dict[Model3dType, Union[Type[Box], Type[Sphere], Type[Cylinder], Type[Mesh]]] = {

--- a/src/python/arcor2/object_types/abstract.py
+++ b/src/python/arcor2/object_types/abstract.py
@@ -10,7 +10,7 @@ from arcor2 import CancelDict, DynamicParamDict
 from arcor2.clients import scene_service
 from arcor2.data.camera import CameraParameters
 from arcor2.data.common import ActionMetadata, Joint, Pose, SceneObject
-from arcor2.data.object_type import Models
+from arcor2.data.object_type import Models, PrimitiveModels
 from arcor2.data.robot import RobotType
 from arcor2.docstring import parse_docstring
 from arcor2.exceptions import Arcor2Exception, Arcor2NotImplemented
@@ -180,6 +180,25 @@ class CollisionObject(GenericWithPose):
         self.enabled = state
 
     set_enabled.__action__ = ActionMetadata()  # type: ignore
+
+
+class VirtualCollisionObject(CollisionObject):
+    """Should be used to represent obstacles or another 'dumb' objects at the
+    workplace."""
+
+    def __init__(
+        self,
+        obj_id: str,
+        name: str,
+        pose: Pose,
+        collision_model: PrimitiveModels,
+        settings: Optional[Settings] = None,
+    ) -> None:
+
+        if settings:
+            raise Arcor2Exception(f"Settings are not supported for {VirtualCollisionObject.__name__}.")  # noqa:PB10
+
+        super().__init__(obj_id, name, pose, collision_model)
 
 
 class RobotException(Arcor2Exception):

--- a/src/python/arcor2_arserver/object_types/utils.py
+++ b/src/python/arcor2_arserver/object_types/utils.py
@@ -106,6 +106,7 @@ def meta_from_def(type_def: Type[Generic], built_in: bool = False) -> ObjectType
             break
 
     obj.settings = get_dataclass_params(get_settings_def(type_def))
+
     return obj
 
 

--- a/src/python/arcor2_arserver/tests/test_objects.py
+++ b/src/python/arcor2_arserver/tests/test_objects.py
@@ -133,3 +133,54 @@ def test_update_object_model(start_processes: None, ars: ARServer) -> None:
 
     assert BoxType.__name__ not in {obj.id for obj in project_service.get_object_type_ids()}
     assert BoxType.__name__ not in {mod.id for mod in project_service.get_models()}
+
+
+def test_virtual_collision_object(start_processes: None, ars: ARServer) -> None:
+    event(ars, events.c.ShowMainScreen)
+
+    assert ars.call_rpc(
+        rpc.s.NewScene.Request(get_id(), rpc.s.NewScene.Request.Args("TestScene")), rpc.s.NewScene.Response
+    ).result
+
+    event(ars, events.s.OpenScene)
+    event(ars, events.s.SceneState)
+
+    name = "vco"
+    box = Box(name, 0.1, 0.1, 0.1)
+    om = ObjectModel(box.type(), box=box)
+
+    add_vco = ars.call_rpc(
+        rpc.s.AddVirtualCollisionObjectToScene.Request(
+            get_id(), rpc.s.AddVirtualCollisionObjectToScene.Request.Args(name, Pose(), om)
+        ),
+        rpc.s.AddVirtualCollisionObjectToScene.Response,
+    )
+
+    assert add_vco.result
+
+    ot_evt = event(ars, events.o.ChangedObjectTypes)
+    assert ot_evt.change_type == ot_evt.Type.ADD
+    assert len(ot_evt.data) == 1
+    assert ot_evt.data[0].object_model == om
+    assert ot_evt.data[0].type == name
+
+    scn_evt = event(ars, events.s.SceneObjectChanged)
+    assert scn_evt.change_type == ot_evt.Type.ADD
+    assert scn_evt.data.name == name
+
+    delete_res_2 = ars.call_rpc(
+        rpc.s.RemoveFromScene.Request(get_id(), rpc.s.RemoveFromScene.Request.Args(scn_evt.data.id)),
+        rpc.s.RemoveFromScene.Response,
+    )
+
+    assert delete_res_2.result
+
+    scn_evt2 = event(ars, events.s.SceneObjectChanged)
+    assert scn_evt2.change_type == ot_evt.Type.REMOVE
+    assert scn_evt2.data.name == name
+
+    ot_evt2 = event(ars, events.o.ChangedObjectTypes)
+    assert ot_evt2.change_type == ot_evt.Type.REMOVE
+    assert len(ot_evt2.data) == 1
+    assert ot_evt2.data[0].object_model == om
+    assert ot_evt2.data[0].type == name

--- a/src/python/arcor2_arserver_data/rpc/scene.py
+++ b/src/python/arcor2_arserver_data/rpc/scene.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Set
 from dataclasses_jsonschema import JsonSchemaMixin
 
 from arcor2.data.common import IdDesc, Parameter, Pose
+from arcor2.data.object_type import ObjectModel
 from arcor2.data.rpc.common import RPC, IdArgs
 
 
@@ -303,6 +304,26 @@ class StartScene(RPC):
 class StopScene(RPC):
     @dataclass
     class Request(RPC.Request):
+        dry_run: bool = False
+
+    @dataclass
+    class Response(RPC.Response):
+        pass
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class AddVirtualCollisionObjectToScene(RPC):
+    @dataclass
+    class Request(RPC.Request):
+        @dataclass
+        class Args(JsonSchemaMixin):
+            name: str
+            pose: Pose
+            model: ObjectModel
+
+        args: Args
         dry_run: bool = False
 
     @dataclass


### PR DESCRIPTION
- `VirtualCollisionObject` is meant as a base for 'dumb' collision objects, with primitive models.
- There is a new RPC `AddVirtualCollisionObjectToScene` which creates a new ObjectType and adds its instance to a scene.
- In the simplest case, each collision object will have its own ObjectType (but it is also possible to add more instances as with other types).
- When the last instance of virtual object is removed, ARServer also removes the ObjectType automatically.