### PR TITLE
fix(arcor2_arserver): adding virtual collision objects

### DIFF
--- a/src/python/arcor2_arserver/rpc/scene.py
+++ b/src/python/arcor2_arserver/rpc/scene.py
@@ -731,7 +731,7 @@ async def add_virtual_collision_object_to_scene_cb(
         assert issubclass(type_def, VirtualCollisionObject)
         actions = object_actions(type_def, ast)
 
-        meta.modified = await storage.update_object_type(meta.to_object_type())
+        meta.modified = await storage.update_object_type(meta.to_object_type(source))
 
         glob.OBJECT_TYPES[meta.type] = ObjectTypeData(meta, type_def, actions, ast)
         add_ancestor_actions(meta.type, glob.OBJECT_TYPES)

--- a/src/python/arcor2_arserver/tests/test_objects.py
+++ b/src/python/arcor2_arserver/tests/test_objects.py
@@ -156,6 +156,9 @@ def test_virtual_collision_object(start_processes: None, ars: ARServer) -> None:
         rpc.s.AddVirtualCollisionObjectToScene.Response,
     )
 
+    ot = project_service.get_object_type(name)
+    assert ot.source
+
     assert add_vco.result
 
     ot_evt = event(ars, events.o.ChangedObjectTypes)
@@ -184,3 +187,5 @@ def test_virtual_collision_object(start_processes: None, ars: ARServer) -> None:
     assert len(ot_evt2.data) == 1
     assert ot_evt2.data[0].object_model == om
     assert ot_evt2.data[0].type == name
+
+    assert name not in {ot.id for ot in project_service.get_object_type_ids()}

--- a/src/python/arcor2_arserver_data/objects.py
+++ b/src/python/arcor2_arserver_data/objects.py
@@ -26,9 +26,9 @@ class ObjectTypeMeta(JsonSchemaMixin):
     settings: List[ParameterMeta] = field(default_factory=list)
     modified: Optional[datetime] = None
 
-    def to_object_type(self) -> ObjectType:
+    def to_object_type(self, source: str = "") -> ObjectType:
 
-        ot = ObjectType(self.type, "", self.description)
+        ot = ObjectType(self.type, source, self.description)
 
         if self.object_model:
             ot.model = self.object_model.model().metamodel()


### PR DESCRIPTION
- `source` was empty when putting OT on the Project service.