### PR TITLE
Visualization action points

### DIFF
--- a/src/python/arcor2/data/events.py
+++ b/src/python/arcor2/data/events.py
@@ -118,8 +118,14 @@ class ActionStateBefore(Event):
     @dataclass
     class Data(JsonSchemaMixin):
 
-        action_id: str
-        parameters: list[str]
+        # required for projects with logic (where actions are defined in the project)
+        # might be also filled for projects without logic
+        action_id: Optional[str] = None
+        parameters: Optional[list[str]] = None
+
+        # required for projects with logic
+        # might or might not be set in other cases
+        action_point_ids: Optional[set[str]] = None
 
     data: Data
 

--- a/src/python/arcor2_arserver/tests/test_project_execution.py
+++ b/src/python/arcor2_arserver/tests/test_project_execution.py
@@ -168,6 +168,7 @@ def test_run_simple_project(start_processes: None, ars: ARServer) -> None:
     act_state_before = event(ars, arcor2_events.ActionStateBefore).data
     assert act_state_before
     assert act_state_before.action_id == action.id
+    assert act_state_before.parameters
     assert len(act_state_before.parameters) == 2
 
     act_state_after = event(ars, arcor2_events.ActionStateAfter).data
@@ -181,6 +182,7 @@ def test_run_simple_project(start_processes: None, ars: ARServer) -> None:
     act2_state_before = event(ars, arcor2_events.ActionStateBefore).data
     assert act2_state_before
     assert act2_state_before.action_id == action2.id
+    assert act2_state_before.parameters
     assert len(act2_state_before.parameters) == 1
 
     act2_state_after = event(ars, arcor2_events.ActionStateAfter).data


### PR DESCRIPTION
This is a merge request for AP visualization, as we have discussed.

Basically I have changed `ActionStateBefore` event scheme, then I have updated runtime `@action` decorator to get AP ids from arguments. Due to this change the `ActionStateBefore` will be dispatched for each action (with or without id or any pose/joints in arguments). This event will be than handled by rest proxy. 

At rest proxy I have added 2 global variables to hold last action state - one for `ActionStateBefore.Data` and another for `ActionStateAfter.Data`, just like you hold `package_state` for example. `ActionStateAfter` will be unset once `ActionStateBefore` is met (at this moment `ActionStateAfter` already belongs to previous action), however `ActionStateBefore` will never be unsettled once set. We have discussed internally, that it is ok, that information about the last AP will remain (will not be unset), even when script state is "Completed" or action has ended (`ActionStateAfter` was fired). `ExecutionInfo` and `packeges/executioninfo` were updated to return AP ids.

As well I have updated tests for `arcor_runtime`, but I guess you might want to check some other things here, so it is an open question what tests should be done.

I ran tests for related services. I did not manage to run typecheck and tests for all services due to (I suppose) `pyk4a`. 
