### PR TITLE
build(kinect): use bundled pyk4a

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -9,7 +9,7 @@ jobs:
   build:
     env:
       PANTS_CONFIG_FILES: pants.ci.toml
-    runs-on: ubuntu-18.04  # because libk4a is not supported on 20.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.9]
@@ -45,7 +45,6 @@ jobs:
     #    ./pants update-build-files --check
     - name: install system dependencies
       run: |
-        ./build-support/install_kinect_prerequisites.sh
         sudo apt install jq
     - name: Lint
       run: |

--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -7,7 +7,8 @@ python_requirements(
             "opencv-contrib-python": ["cv2"],
             "websocket-client": ["websocket"],
             "pyhumps": ["humps"],
-            "pyserial": ["serial"]
+            "pyserial": ["serial"],
+            "pyk4a-bundle": ["pyk4a"]
           },
     overrides={
         "apispec-webframeworks": {"dependencies": [":setuptools", ":Flask"]},  # https://github.com/marshmallow-code/apispec-webframeworks/issues/99

--- a/3rdparty/constraints.txt
+++ b/3rdparty/constraints.txt
@@ -104,7 +104,7 @@ pycparser==2.21
 pyglet==1.5.21
 Pygments==2.11.2
 pyhumps==3.5.0
-pyk4a==1.3.0
+pyk4a-bundle==1.3.0.2
 PyOpenGL==3.1.0
 pyparsing==3.0.7
 pyrender==0.1.45

--- a/3rdparty/requirements.txt
+++ b/3rdparty/requirements.txt
@@ -21,7 +21,7 @@ orjson==3.6.6
 packaging==21.3
 Pillow==9.0.0
 pyhumps==3.5.0
-pyk4a==1.3.0
+pyk4a-bundle==1.3.0.2
 pyserial==3.5
 pytest-asyncio==0.17.2
 pytest-randomly==3.11.0

--- a/build-support/install_kinect_prerequisites.sh
+++ b/build-support/install_kinect_prerequisites.sh
@@ -1,9 +1,0 @@
-curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-sudo apt-add-repository https://packages.microsoft.com/ubuntu/"$(lsb_release -rs)"/prod
-sudo apt-get update
-export DEBIAN_FRONTEND="noninteractive"
-echo 'libk4a1.4 libk4a1.4/accepted-eula-hash string 0f5d5c5de396e4fee4c0753a21fee0c1ed726cf0316204edda484f08cb266d76' | sudo debconf-set-selections
-echo 'libk4a1.4 libk4a1.4/accept-eula boolean true' | sudo debconf-set-selections
-sudo apt-get install -y libk4a1.4 libk4a1.4-dev
-sudo wget https://raw.githubusercontent.com/microsoft/Azure-Kinect-Sensor-SDK/develop/scripts/99-k4a.rules -P /etc/udev/rules.d/
-sudo udevadm control --reload-rules && udevadm trigger

--- a/docker/Dockerfile-kinect-azure
+++ b/docker/Dockerfile-kinect-azure
@@ -1,51 +1,17 @@
-FROM ubuntu:18.04
-
-RUN apt-get update \
-  && apt-get install --yes --no-install-recommends \
-  curl \
-  build-essential \
-  git \
-  python3.9 \
-  python3.9-venv \
-  python3.9-dev \
-  python3-distutils \
-  python3-pip \
-  unzip
-
-RUN pip3 install --upgrade \
-  pip
+ARG version=latest
+FROM arcor2/arcor2_base:$version
 
 COPY . /root/arcor2/
 
-ENV TZ=Europe/Kiev
+RUN cd ~/arcor2 \
+	&& ./pants package src/python/arcor2_kinect_azure/scripts:kinect_azure
 
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+FROM arcor2/arcor2_dist_base:$version
+
+COPY --from=0 /root/arcor2/dist/src.python.arcor2_kinect_azure.scripts/kinect_azure.pex /root/kinect_azure.pex
 
 RUN apt-get update \
-     && apt-get install -y gnupg2 software-properties-common libpython3.9-dev
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN echo 'libk4a1.4 libk4a1.4/accepted-eula-hash string 0f5d5c5de396e4fee4c0753a21fee0c1ed726cf0316204edda484f08cb266d76' | debconf-set-selections \
-     && echo 'libk4a1.4 libk4a1.4/accept-eula boolean true' | debconf-set-selections
-
-RUN curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-     && apt-add-repository https://packages.microsoft.com/ubuntu/18.04/prod \
-     && apt-get update \         
-     && apt-get install -y libk4a1.4 libk4a1.4-dev
-
-RUN apt-get update \      
-    && apt-get install -y python3.6-dev
-
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV PANTS_IGNORE_UNRECOGNIZED_ENCODING=1
-
-RUN cd ~/arcor2 \
-	&& ./pants package src/python/arcor2_kinect_azure/scripts:kinect_azure 
-
-RUN mv /root/arcor2/dist/src.python.arcor2_kinect_azure.scripts/kinect_azure.pex /root/kinect_azure.pex
+	&& apt-get install -y -q libgl1-mesa-glx libglib2.0-0
 
 COPY docker/start-kinect-azure.sh ./start.sh
 
-CMD ["/bin/sh", "/start.sh"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,7 +2,7 @@
 
 export DOCKER_BUILDKIT=1
 export UBUNTU_VERSION="20.04"
-export PYTHON_VERSION="3.9-slim-buster"
+export PYTHON_VERSION="3.9-slim-bullseye"
 build_base_image () {
         docker pull ubuntu:"$UBUNTU_VERSION"
 	docker build ../ -f Dockerfile-base -t arcor2/arcor2_base:"$VERSION" --build-arg version="$UBUNTU_VERSION"
@@ -81,7 +81,7 @@ if [ $# -eq 0 ]; then
     echo "Usage:"
     echo "sudo sh build.sh VERSION [arserver] [build] [execution] [execution-proxy] [kinect-azure] [mocks] [devel] [dobot] [calibration] [upload-fit-demo] [upload-kinali] [upload-builtin]"
     echo "sudo sh build.sh VERSION all"
-    echo "$VERSION specifies version of base image. Optional parametes specifies which images should be build using version from their VERSION file."
+    echo "$VERSION specifies version of base image. Optional parameters specifies which images should be build using version from their VERSION file."
     echo "If no optional parameter is specified, base image is build with version $VERSION."
     echo "If second parameter is 'all', all other parameters are ignored and all images are build."
     exit 1
@@ -93,7 +93,6 @@ if [ $# -eq 1 ]; then
 	build_base_image
 	exit 0
 fi
-
 
 build_dist_base_image
 

--- a/src/python/arcor2_kinect_azure/README.md
+++ b/src/python/arcor2_kinect_azure/README.md
@@ -4,7 +4,12 @@
 
 - By default, the service runs on port 5016.
   - This can be changed by setting `ARCOR2_KINECT_AZURE_URL`.
-- Kinect SDK has to be installed beforehand (`./build-support/install_kinect_prerequisites.sh`).
+- You may need to run following commands when using the real sensor to set permissions:
+
+```bash
+sudo wget https://raw.githubusercontent.com/microsoft/Azure-Kinect-Sensor-SDK/develop/scripts/99-k4a.rules -P /etc/udev/rules.d/
+sudo udevadm control --reload-rules && udevadm trigger
+```
 
 ## Environment variables
 


### PR DESCRIPTION
- No need to install kinect sdk.
- Docker image is now based on slim buster as other images.
- Please note: the current version of `pyk4a-bundle` has some issues and does not work.
- ...however, this simplifies work with our repo, so it's integrated anyway.