### PR TITLE
fix(arcor2): project service client

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -8,6 +8,7 @@ python_requirements(
         "websocket-client": ["websocket"],
         "pyhumps": ["humps"],
         "pyserial": ["serial"],
+        "python-dateutil": ["dateutil"],
     },
     overrides={
         "apispec-webframeworks": {

--- a/3rdparty/constraints.txt
+++ b/3rdparty/constraints.txt
@@ -23,6 +23,7 @@ colorlog==6.6.0
 cycler==0.11.0
 Cython==0.29.28
 dataclasses-jsonschema==2.15.1
+python-dateutil==2.8.2
 debugpy==1.6.0
 decorator==5.1.1
 defusedxml==0.7.1
@@ -140,6 +141,7 @@ tqdm==4.64.0
 traitlets==5.2.0
 trimesh==3.12.0
 types-aiofiles==0.8.8
+types-python-dateutil==2.8.15
 types-orjson==3.6.2
 types-PyYAML==6.0.7
 types-requests==2.27.25

--- a/3rdparty/requirements.txt
+++ b/3rdparty/requirements.txt
@@ -7,6 +7,7 @@ autopep8==1.6.0
 colorlog==6.6.0
 Cython==0.29.28
 dataclasses-jsonschema[fast-validation,apispec]==2.15.1
+python-dateutil==2.8.2
 flask_cors==3.0.10
 flask-swagger-ui==3.36.0
 Flask==2.1.2
@@ -32,6 +33,7 @@ setuptools==62.2.0
 sqlitedict==2.0.0
 types-aiofiles==0.8.8
 types-orjson==3.6.2
+types-python-dateutil==2.8.15
 types-setuptools==57.4.14
 types-requests==2.27.25
 types-PyYAML==6.0.7

--- a/src/python/arcor2/clients/project_service.py
+++ b/src/python/arcor2/clients/project_service.py
@@ -2,6 +2,8 @@ import os
 from datetime import datetime
 from typing import Optional
 
+from dateutil.parser import parse
+
 from arcor2 import rest
 from arcor2.data.common import Asset, IdDesc, Project, ProjectParameter, ProjectSources, Scene, SceneObjectOverride
 from arcor2.data.object_type import MODEL_MAPPING, Mesh, MeshList, MetaModel3d, Model, Model3dType, ObjectType
@@ -178,7 +180,7 @@ def get_object_type_ids() -> list[IdDesc]:
 def update_object_type(object_type: ObjectType) -> datetime:
 
     assert object_type.id
-    return datetime.fromisoformat(rest.call(rest.Method.PUT, f"{URL}/object_type", body=object_type, return_type=str))
+    return parse(rest.call(rest.Method.PUT, f"{URL}/object_type", body=object_type, return_type=str))
 
 
 @handle(ProjectServiceException, logger, message="Failed to delete the object type.")
@@ -198,7 +200,7 @@ def get_project_parameters(project_id: str) -> list[ProjectParameter]:
 
 @handle(ProjectServiceException, logger, message="Failed to add or update project parameters.")
 def update_project_parameters(project_id: str, parameters: list[ProjectParameter]) -> datetime:
-    return datetime.fromisoformat(
+    return parse(
         rest.call(rest.Method.GET, f"{URL}/projects/{project_id}/parameters", body=parameters, return_type=str)
     )
 
@@ -227,7 +229,7 @@ def get_project_sources(project_id: str) -> ProjectSources:
 def update_project(project: Project) -> datetime:
 
     assert project.id
-    return datetime.fromisoformat(rest.call(rest.Method.PUT, f"{URL}/project", return_type=str, body=project))
+    return parse(rest.call(rest.Method.PUT, f"{URL}/project", return_type=str, body=project))
 
 
 @handle(ProjectServiceException, logger, message="Failed to add or update the project sources.")
@@ -281,7 +283,7 @@ def get_scene(scene_id: str) -> Scene:
 def update_scene(scene: Scene) -> datetime:
 
     assert scene.id
-    return datetime.fromisoformat(rest.call(rest.Method.PUT, f"{URL}/scene", return_type=str, body=scene))
+    return parse(rest.call(rest.Method.PUT, f"{URL}/scene", return_type=str, body=scene))
 
 
 @handle(ProjectServiceException, logger, message="Failed to delete the scene.")


### PR DESCRIPTION
- `dateutil` is now used to parse `datetime` from iso format.
- There was a `ValueError` for more than 6 decimal places.