### PR TITLE
refactor: shuffling of scene objects moved from Build to Project mock

### DIFF
--- a/src/python/arcor2_build/scripts/build.py
+++ b/src/python/arcor2_build/scripts/build.py
@@ -149,11 +149,6 @@ def _publish(project_id: str, package_name: str) -> RespT:
                 obj_types = set(cached_scene.object_types)
                 obj_types_with_models: set[str] = set()
 
-                if __debug__:  # this should uncover potential problems with order in which ObjectTypes are processed
-                    import random
-
-                    random.shuffle(scene.objects)
-
                 for scene_obj in scene.objects:
                     if scene_obj.type in types_dict:
                         continue
@@ -540,6 +535,9 @@ def main() -> None:
 
     args = parser.parse_args()
     logger.setLevel(args.debug)
+
+    if __debug__:
+        logger.warning("Development mode.")
 
     run_app(
         app,

--- a/src/python/arcor2_mocks/scripts/mock_project.py
+++ b/src/python/arcor2_mocks/scripts/mock_project.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
+import copy
+import random
 from datetime import datetime, timezone
 
 import humps
@@ -105,9 +107,16 @@ def get_project(id: str) -> RespT:
     """
 
     try:
-        return jsonify(humps.camelize(PROJECTS[id].to_dict()))
+        project_copy = copy.deepcopy(PROJECTS[id])
     except KeyError:
         raise NotFound(f"Project {id} was not found.")
+
+    random.shuffle(project_copy.action_points)
+    random.shuffle(project_copy.logic)
+    random.shuffle(project_copy.object_overrides)
+    random.shuffle(project_copy.parameters)
+
+    return jsonify(humps.camelize(project_copy.to_dict()))
 
 
 @app.route("/projects/<string:id>", methods=["DELETE"])
@@ -265,9 +274,13 @@ def get_scene(id: str) -> RespT:
     """
 
     try:
-        return jsonify(humps.camelize(SCENES[id].to_dict()))
+        scene_copy = copy.deepcopy(SCENES[id])
     except KeyError:
         raise NotFound(f"Scene {id} was not found.")
+
+    random.shuffle(scene_copy.objects)
+
+    return jsonify(humps.camelize(scene_copy.to_dict()))
 
 
 @app.route("/scenes/<string:id>", methods=["DELETE"])


### PR DESCRIPTION
- For testing purposes, there used to be shuffling of scene objects to make sure that the order does not matter.
- This probably fits better to a mock of the Project service than into the Build service.
- Moreover, the shuffling of stuff in a project was added.