### PR TITLE
fix: configure scene service URL for Docker ur-demo

### DIFF
--- a/build-support/install_ur_dependencies.sh
+++ b/build-support/install_ur_dependencies.sh
@@ -2,6 +2,6 @@
 
 # Keep ROS packages pinned so CI and the arcor2_ur image exercise the same UR stack over time.
 apt-get install -y -q --no-install-recommends \
-	ros-jazzy-ros-base=0.11.0-1noble.20260126.203129 \
-	ros-jazzy-ur=3.7.0-1noble.20260126.222208 \
-	ros-jazzy-moveit-py=2.12.4-1noble.20260126.215035
+	ros-jazzy-ros-base=0.11.0-1noble.20260412.071950 \
+	ros-jazzy-ur=3.7.0-1noble.20260412.082316 \
+	ros-jazzy-moveit-py=2.12.4-1noble.20260412.073026

--- a/compose-files/ur-demo/docker-compose.lab.yml
+++ b/compose-files/ur-demo/docker-compose.lab.yml
@@ -4,6 +4,7 @@ services:
       - ARCOR2_UR_ROBOT_IP=192.168.80.2
     volumes:
       - ./robot_calibration.yaml:/root/robot_calibration.yaml
+    network_mode: "host"  # ObjectType has to connect to localhost:5012
   ur-demo-arserver:
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/compose-files/ur-demo/docker-compose.lab.yml
+++ b/compose-files/ur-demo/docker-compose.lab.yml
@@ -4,4 +4,13 @@ services:
       - ARCOR2_UR_ROBOT_IP=192.168.80.2
     volumes:
       - ./robot_calibration.yaml:/root/robot_calibration.yaml
-    network_mode: "host"  # ObjectType has to connect to localhost:5012
+  ur-demo-arserver:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - ARCOR2_SCENE_SERVICE_URL=http://host.docker.internal:5012
+  ur-demo-execution:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - ARCOR2_SCENE_SERVICE_URL=http://host.docker.internal:5012


### PR DESCRIPTION
This fixes communication with the Scene service in the UR Docker demo.

The ARServer and execution containers could not reach the Scene service running on the host, which caused:

`Failed to communicate with the Scene service. Failed to get scene state.`